### PR TITLE
Catch StackOverflowError on host function calls

### DIFF
--- a/runtime/src/main/java/run/endive/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/run/endive/runtime/InterpreterMachine.java
@@ -123,6 +123,8 @@ public class InterpreterMachine implements Machine {
                 }
             } catch (WasmException e) {
                 THROW_REF(instance, instance.registerException(e), stack, stackFrame, callStack);
+            } catch (StackOverflowError e) {
+                throw new WasmEngineException("call stack exhausted", e);
             } finally {
                 if (!callStack.isEmpty() && callStack.peek() == stackFrame) {
                     callStack.pop();

--- a/runtime/src/test/java/run/endive/runtime/WasmModuleTest.java
+++ b/runtime/src/test/java/run/endive/runtime/WasmModuleTest.java
@@ -24,6 +24,7 @@ import run.endive.corpus.CorpusResources;
 import run.endive.wasm.InvalidException;
 import run.endive.wasm.Parser;
 import run.endive.wasm.UninstantiableException;
+import run.endive.wasm.WasmEngineException;
 import run.endive.wasm.WasmModule;
 import run.endive.wasm.types.CatchOpCode;
 import run.endive.wasm.types.FunctionType;
@@ -808,5 +809,27 @@ public class WasmModuleTest {
         // verify against a reference that doesn't exist
         var isNull3 = instance.exports().function("is_null").apply(1L)[0];
         assertEquals(1L, isNull3);
+    }
+
+    @Test
+    public void hostFunctionStackOverflowShouldBeWrapped() {
+        var func =
+                new HostFunction(
+                        "console",
+                        "log",
+                        FunctionType.of(List.of(ValType.I32, ValType.I32), List.of()),
+                        (Instance inst, long... args) -> {
+                            throw new StackOverflowError("simulated stack overflow");
+                        });
+        var instance =
+                Instance.builder(loadModule("compiled/host-function.wat.wasm"))
+                        .withImportValues(
+                                ImportValues.builder()
+                                        .addFunction(new HostFunction[] {func})
+                                        .build())
+                        .build();
+        var logIt = instance.export("logIt");
+        var e = assertThrows(WasmEngineException.class, logIt::apply);
+        assertEquals("call stack exhausted", e.getMessage());
     }
 }


### PR DESCRIPTION
The wasm-to-wasm call path already catches StackOverflowError and wraps it as WasmEngineException. The host function call path did not, so a StackOverflowError inside a host callback would leak straight to the embedder. Apply the same pattern to host calls.