### PR TITLE
Increase MemCopyWorkaround warmup iterations to 10k

### DIFF
--- a/runtime/src/main/java/run/endive/runtime/MemCopyWorkaround.java
+++ b/runtime/src/main/java/run/endive/runtime/MemCopyWorkaround.java
@@ -50,7 +50,7 @@ public final class MemCopyWorkaround {
             I32GEUFunc noop4 = (a, b) -> b;
 
             // Warm up the JIT... to make it see memoryCopyFunc.apply is megamorphic
-            for (int i = 0; i < 1000; i++) {
+            for (int i = 0; i < 10_000; i++) {
                 memoryCopyFunc = noop1;
                 MemCopyWorkaround.memoryCopy(0, 0, 0, null);
                 memoryCopyFunc = noop2;


### PR DESCRIPTION
The JIT warmup loop ran 1000 iterations which was insufficient on some CI environments (ubuntu Java 11) to reliably prevent the C2 compiler from inlining the megamorphic call site. Bumping to 10000 iterations fixes the flaky out-of-bounds memory access in compiler-tests.