### PR TITLE
Add annotations-processor and log to migration guide

### DIFF
--- a/docs/docs/migration/from-chicory.md
+++ b/docs/docs/migration/from-chicory.md
@@ -18,6 +18,8 @@ This guide documents all breaking changes for users migrating from Chicory.
 | `com.dylibso.chicory:wasm` | `run.endive:wasm` |
 | `com.dylibso.chicory:wasi` | `run.endive:wasi` |
 | `com.dylibso.chicory:annotations` | `run.endive:annotations` |
+| `com.dylibso.chicory:annotations-processor` | `run.endive:annotations-processor` |
+| `com.dylibso.chicory:log` | `run.endive:log` |
 | `com.dylibso.chicory:bom` | `run.endive:bom` |
 
 All module artifact names (`runtime`, `compiler`, `wasm`, etc.) are unchanged.


### PR DESCRIPTION
I tested the migration guide against the major dependencies, and just this came up.

These artifacts are used by many downstream projects (annotations-processor by 5 of 8 tested projects, log by 2) but were not explicitly listed in the Maven coordinates table.