### PR TITLE
Skip OWASP dependency check for non-published modules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,18 @@ Our priority is to focus on implementing [proposals](https://github.com/WebAssem
 
 Because we are all humans, and to ensure Endive evolves in the right direction, all changes must pass continuous integration before being merged. The CI is based on GitHub Actions, which means that pull requests will receive automatic feedback.  Please watch out for the results of these workflows to see if your PR passes all tests.
 
+### OWASP Dependency Check
+
+A nightly [OWASP Dependency Check](https://dependency-check.github.io/DependencyCheck/) runs against all modules and fails the build if any dependency has a CVSS score of 7 or higher. Only published (BOM) modules are scanned; internal and test-only modules opt out by setting:
+
+```xml
+<properties>
+  <dependency-check.skip>true</dependency-check.skip>
+</properties>
+```
+
+If you add a new module that is **not** published in the BOM, add the property above to its `pom.xml`. New modules without this property will be scanned by default.
+
 ### IntelliJ default limits
 
 Some of the SIMD tests are exceeding the default limits of IntelliJ.

--- a/annotations/it/pom.xml
+++ b/annotations/it/pom.xml
@@ -13,6 +13,10 @@
   <name>Endive - Annotations - IT</name>
   <description>Integration tests for the Endive annotations</description>
 
+  <properties>
+    <dependency-check.skip>true</dependency-check.skip>
+  </properties>
+
   <dependencies>
     <!-- Dummy dependencies to force reactor ordering -->
     <dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -12,6 +12,10 @@
   <name>Endive - BOM</name>
   <description>Bill of Materials (BOM)</description>
 
+  <properties>
+    <dependency-check.skip>true</dependency-check.skip>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/compiler-tests/pom.xml
+++ b/compiler-tests/pom.xml
@@ -14,6 +14,10 @@
   <name>Endive - Compiler tests</name>
   <description>Spec tests for the compiler</description>
 
+  <properties>
+    <dependency-check.skip>true</dependency-check.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.approvaltests</groupId>

--- a/docs-lib/pom.xml
+++ b/docs-lib/pom.xml
@@ -13,4 +13,8 @@
   <name>Endive - Docs Lib</name>
   <description>INTERNAL USAGE ONLY - utils to verify the docs</description>
 
+  <properties>
+    <dependency-check.skip>true</dependency-check.skip>
+  </properties>
+
 </project>

--- a/fuzz/pom.xml
+++ b/fuzz/pom.xml
@@ -15,6 +15,7 @@
 
   <properties>
     <skipTests>true</skipTests>
+    <dependency-check.skip>true</dependency-check.skip>
   </properties>
 
   <dependencies>

--- a/jmh/pom.xml
+++ b/jmh/pom.xml
@@ -13,6 +13,10 @@
   <name>Endive - JMH</name>
   <description>JMH tests for the Endive runtime</description>
 
+  <properties>
+    <dependency-check.skip>true</dependency-check.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>

--- a/machine-tests/pom.xml
+++ b/machine-tests/pom.xml
@@ -12,6 +12,10 @@
 
   <name>Endive - Machines tests</name>
 
+  <properties>
+    <dependency-check.skip>true</dependency-check.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>run.endive</groupId>

--- a/nightly-testsuite/pom.xml
+++ b/nightly-testsuite/pom.xml
@@ -12,6 +12,10 @@
 
   <name>Endive - Nigthly testsuite</name>
 
+  <properties>
+    <dependency-check.skip>true</dependency-check.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>run.endive</groupId>

--- a/runtime-tests/pom.xml
+++ b/runtime-tests/pom.xml
@@ -13,6 +13,10 @@
   <name>Endive - Runtime tests</name>
   <description>Tests for the Endive runtime using the WebAssembly testsuite</description>
 
+  <properties>
+    <dependency-check.skip>true</dependency-check.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>run.endive</groupId>

--- a/test-gen-lib/pom.xml
+++ b/test-gen-lib/pom.xml
@@ -13,6 +13,10 @@
   <name>Endive - Test Gen Lib</name>
   <description>A library to generate tests from the WebAssembly testsuite</description>
 
+  <properties>
+    <dependency-check.skip>true</dependency-check.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/test-gen-plugin/pom.xml
+++ b/test-gen-plugin/pom.xml
@@ -13,6 +13,10 @@
   <name>Endive - Test Gen Maven Plugin</name>
   <description>A Maven Plugin to generate tests from the WebAssembly testsuite</description>
 
+  <properties>
+    <dependency-check.skip>true</dependency-check.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.github.javaparser</groupId>

--- a/wasi-test-gen-plugin/pom.xml
+++ b/wasi-test-gen-plugin/pom.xml
@@ -13,6 +13,10 @@
   <name>Endive - WASI Test Gen Maven Plugin</name>
   <description>A Maven Plugin to generate tests from the WebAssembly wasi-testsuite</description>
 
+  <properties>
+    <dependency-check.skip>true</dependency-check.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/wasi-tests/pom.xml
+++ b/wasi-tests/pom.xml
@@ -13,6 +13,10 @@
   <name>Endive - WASI Tests</name>
   <description>WASI Preview 1 tests for Endive</description>
 
+  <properties>
+    <dependency-check.skip>true</dependency-check.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.roastedroot</groupId>

--- a/wasm-corpus/pom.xml
+++ b/wasm-corpus/pom.xml
@@ -10,6 +10,10 @@
   <name>Endive - WASM Corpus</name>
   <description>A Corpus of guest modules for testing</description>
 
+  <properties>
+    <dependency-check.skip>true</dependency-check.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.velocity</groupId>


### PR DESCRIPTION
## Summary
- The nightly OWASP dependency check was failing on `wasm-corpus` due to CVEs in Velocity 1.7 transitive dependencies (CVE-2015-6420 CVSS 9.8, CVE-2020-13936 CVSS 8.8). These are internal test modules not shipped to users.
- Added `<dependency-check.skip>true</dependency-check.skip>` to all 14 non-BOM module POMs so only published artifacts are scanned.
- New modules are scanned by default — internal/test modules must explicitly opt out.
- Documented the convention in CONTRIBUTING.md under "OWASP Dependency Check".

## Test plan
- [x] `mvn -Dquickly` builds successfully
- [x] `mvn spotless:check` passes
- [ ] Re-run the OWASP dependency check workflow via `workflow_dispatch` to confirm it passes