### PR TITLE
Increase release timeout to 2 hours

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    timeout-minutes: 150
 
     steps:
       - name: Checkout

--- a/pom.xml
+++ b/pom.xml
@@ -1096,7 +1096,7 @@
               <publishingServerId>central</publishingServerId>
               <autoPublish>true</autoPublish>
               <waitUntil>published</waitUntil>
-              <waitMaxTime>3600</waitMaxTime>
+              <waitMaxTime>7200</waitMaxTime>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION

- Increase `waitMaxTime` from 3600s (1h) to 7200s (2h) in the `central-publishing-maven-plugin` config
- Add `timeout-minutes: 150` to the release workflow job as a safety net
