### PR TITLE
Allow empty strings as import names for function imports

### DIFF
--- a/annotations/processor/src/main/java/run/endive/annotations/processor/WasmModuleProcessor.java
+++ b/annotations/processor/src/main/java/run/endive/annotations/processor/WasmModuleProcessor.java
@@ -28,10 +28,7 @@ import run.endive.wasm.WasmModule;
 
 public final class WasmModuleProcessor extends AbstractModuleProcessor {
     private static final StandardLocation[] LOCATIONS = {
-            CLASS_PATH,
-            ANNOTATION_PROCESSOR_PATH,
-            SOURCE_PATH,
-            CLASS_OUTPUT,
+        CLASS_PATH, ANNOTATION_PROCESSOR_PATH, SOURCE_PATH, CLASS_OUTPUT,
     };
 
     @Override

--- a/wasm/src/main/java/run/endive/wasm/Parser.java
+++ b/wasm/src/main/java/run/endive/wasm/Parser.java
@@ -679,16 +679,13 @@ public final class Parser {
             String importName = readName(buffer);
             ExternalType descType;
             try {
-                descType = ExternalType.byId((int) readVarUInt32(buffer));
+                descType = ExternalType.byId(readByte(buffer));
             } catch (RuntimeException e) {
                 throw new MalformedException("malformed import kind", e);
             }
             switch (descType) {
                 case FUNCTION:
                     {
-                        if (moduleName.isEmpty() && importName.isEmpty()) {
-                            throw new MalformedException("malformed import kind");
-                        }
                         importSection.addImport(
                                 new FunctionImport(
                                         moduleName, importName, (int) readVarUInt32(buffer)));
@@ -860,7 +857,7 @@ public final class Parser {
         // Parse individual functions in the function section
         for (int i = 0; i < exportCount; i++) {
             var name = readName(buffer, false);
-            var exportType = ExternalType.byId((int) readVarUInt32(buffer));
+            var exportType = ExternalType.byId(readByte(buffer));
             var index = (int) readVarUInt32(buffer);
             exportSection.addExport(new Export(name, index, exportType));
         }


### PR DESCRIPTION
The WebAssembly spec permits empty names (zero-length UTF-8 strings) as valid import module and field names. The removed check incorrectly rejected function imports when both names were empty, while other import types (table, memory, global, tag) already accepted them.

Big reported here: https://github.com/roastedroot/endive-cm/pull/15#issuecomment-4866245332

This was a leftover from an earlier iteration of the `binary.wast` malformed import kind handling, the check got moved into the `FUNCTION` case but was never removed when the proper `byId()` catch was added.