### PR TITLE
Add typilot to Endive adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -21,3 +21,4 @@ Organizations and projects using Endive (formerly Chicory) in production:
 * [Bazel](https://github.com/bazelbuild/bazel) - WebAssembly execution in repo rules
 * [WildFly AI Feature Pack](https://github.com/wildfly-extras/wildfly-ai-feature-pack)
 * Quarkus extensions: [quarkus-chicory](https://github.com/quarkiverse/quarkus-chicory), [quarkus-proxy-wasm](https://github.com/quarkiverse/quarkus-proxy-wasm), [quarkus-quickjs4j](https://github.com/quarkiverse/quarkus-quickjs4j), [quarkus-grpc-zero](https://github.com/quarkiverse/quarkus-grpc-zero)
+* [Typilot](https://github.com/ixmoyren/typilot) - An IntelliJ IDEA plugin for the Typst language, lexical analysis and language analysis are supported by `typst-syntax` and `Endive`


### PR DESCRIPTION
Typilot is an IntelliJ IDEA plugin for the [Typst](https://typst.org/) language, built on `typst-syntax`, `endive`, `tinymist` and `lsp4ij`.

In building the PSI tree for the IntelliJ platform language plugin, the core lexing and parsing are primarily driven by `typst-syntax` and `endive`. ` typst-syntax` is the official parser maintained by the Typst project. 

I compile the `typst-syntax` wrapper into WebAssembly, and  then endive converts the wasm into bytecode for use by other modules in Typliot. 

The approach for compiling the typst-syntax wrapper to WebAssembly is inspired by the [lumis4j](https://github.com/roastedroot/lumis4j) project. The difference from lumis4j is that the typst-syntax wrapper needs to handle structs and serialization (of course, once endive's Component Model matures, this workaround won't be necessary). 

This project serves as a demonstration of integrating a Rust library into a Java/Kotlin project.