### PR TITLE
Replace deprecated Maven license plugin parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -740,6 +740,7 @@
             </goals>
             <phase>validate</phase>
             <configuration>
+              <failOnMissing>true</failOnMissing>
               <failOnBlacklist>true</failOnBlacklist>
               <includedLicenses>
                 <includedLicense>Apache-2.0</includedLicense>
@@ -769,7 +770,6 @@
                 <includedLicense>Public Domain</includedLicense>
                 <includedLicense>GNU General Public License (GPL), version 2, with the Classpath exception</includedLicense>
               </includedLicenses>
-              <failIfWarning>true</failIfWarning>
               <excludedScopes>test</excludedScopes>
             </configuration>
           </execution>


### PR DESCRIPTION
The Maven build was previously logging a warning, for example:
> [INFO] --- license:2.7.1:add-third-party (check-licenses) @ compiler ---
> [WARNING]  Parameter 'failIfWarning' (user property 'license.failIfWarning') is deprecated: since 1.14, use now failOnMissing or failOnBlacklist.

Based on the [source code of the plugin](https://github.com/mojohaus/license-maven-plugin/blob/2.7.1/src/main/java/org/codehaus/mojo/license/AbstractAddThirdPartyMojo.java#L1061-L1081) it looks like `failIfWarning` indeed acts like a combination of `failOnMissing` and `failOnBlacklist`. The parameter `failOnBlacklist` was already set to `true`, so I additionally set `failOnMissing` to `true` as well.