### PR TITLE
Fix lowercasing without `Locale.ROOT`

### DIFF
--- a/wasi/src/main/java/run/endive/wasi/WasiPreview1.java
+++ b/wasi/src/main/java/run/endive/wasi/WasiPreview1.java
@@ -135,7 +135,7 @@ public final class WasiPreview1 implements Closeable {
             } catch (ClassNotFoundException e) {
                 // Fallback: check known system property
                 String runtime = System.getProperty("java.runtime.name");
-                return runtime != null && runtime.toLowerCase(Locale.ENGLISH).contains("android");
+                return runtime != null && runtime.toLowerCase(Locale.ROOT).contains("android");
             }
         }
 

--- a/wasm/src/main/java/run/endive/wasm/Parser.java
+++ b/wasm/src/main/java/run/endive/wasm/Parser.java
@@ -274,7 +274,7 @@ public final class Parser {
                     e);
         }
         if (messageDigest != null) {
-            String algo = DIGEST_ALGORITHM.toLowerCase(Locale.getDefault()).replace(":", "");
+            String algo = DIGEST_ALGORITHM.toLowerCase(Locale.ROOT).replace(":", "");
             moduleBuilder.withDigest(
                     algo + ":" + Base64.getEncoder().encodeToString(messageDigest.digest()));
         }


### PR DESCRIPTION
Using another locale makes the result potentially dependent on the OS config (especially the `Locale.getDefault()` usage was problematic).