### PR TITLE
Remove incorrect `Deprecated#since` values

### DIFF
--- a/compiler/src/main/java/run/endive/experimental/aot/AotMachine.java
+++ b/compiler/src/main/java/run/endive/experimental/aot/AotMachine.java
@@ -12,7 +12,7 @@ import run.endive.wasm.WasmEngineException;
  * This class is deprecated and will be removed in a future version. Please use
  * the {@link run.endive.compiler.MachineFactoryCompiler} instead.
  */
-@Deprecated(since = "1.4.0")
+@Deprecated
 public final class AotMachine implements Machine {
 
     private final Machine machine;
@@ -24,7 +24,7 @@ public final class AotMachine implements Machine {
      *
      * @param instance the instance to use for the machine
      */
-    @Deprecated(since = "1.4.0")
+    @Deprecated
     public AotMachine(Instance instance) {
         this.machine = new MachineFactory(instance.module()).apply(instance);
     }

--- a/runtime/src/main/java/run/endive/runtime/GlobalInstance.java
+++ b/runtime/src/main/java/run/endive/runtime/GlobalInstance.java
@@ -16,7 +16,7 @@ public class GlobalInstance {
     /**
      * @deprecated use {@link #builder()}
      */
-    @Deprecated(since = "use builder()")
+    @Deprecated
     public GlobalInstance(Value value) {
         this(value, MutabilityType.Const);
     }
@@ -24,7 +24,7 @@ public class GlobalInstance {
     /**
      * @deprecated use {@link #builder()}
      */
-    @Deprecated(since = "use builder()")
+    @Deprecated
     public GlobalInstance(Value value, MutabilityType mutabilityType) {
         this.valueLow = value.raw();
         this.valueHigh = 0;
@@ -35,7 +35,7 @@ public class GlobalInstance {
     /**
      * @deprecated use {@link #builder()}
      */
-    @Deprecated(since = "use builder()")
+    @Deprecated
     public GlobalInstance(
             long valueLow, long valueHigh, ValueType valueType, MutabilityType mutabilityType) {
         this.valueLow = valueLow;
@@ -47,7 +47,7 @@ public class GlobalInstance {
     /**
      * @deprecated use {@link #builder()}
      */
-    @Deprecated(since = "use builder()")
+    @Deprecated
     public GlobalInstance(
             long valueLow, long valueHigh, ValType valType, MutabilityType mutabilityType) {
         this.valueLow = valueLow;

--- a/runtime/src/main/java/run/endive/runtime/HostFunction.java
+++ b/runtime/src/main/java/run/endive/runtime/HostFunction.java
@@ -10,7 +10,7 @@ public class HostFunction extends ImportFunction {
     /**
      * @deprecated use {@link #HostFunction(String, String, FunctionType, WasmFunctionHandle)}
      */
-    @Deprecated(since = "1.3.0")
+    @Deprecated
     public HostFunction(
             String moduleName,
             String symbolName,

--- a/runtime/src/main/java/run/endive/runtime/ImportFunction.java
+++ b/runtime/src/main/java/run/endive/runtime/ImportFunction.java
@@ -15,7 +15,7 @@ public class ImportFunction implements ImportValue {
     // Optional: source instance for cross-module canonical type matching
     private final Instance sourceInstance;
 
-    @Deprecated(since = "1.3.0")
+    @Deprecated
     protected static List<ValType> convert(List objs) {
         var result = new ArrayList<ValType>(objs.size());
         for (var v : objs) {
@@ -51,7 +51,7 @@ public class ImportFunction implements ImportValue {
         this.sourceInstance = sourceInstance;
     }
 
-    @Deprecated(since = "1.3.0")
+    @Deprecated
     public ImportFunction(
             String module,
             String name,

--- a/runtime/src/main/java/run/endive/runtime/WasmArray.java
+++ b/runtime/src/main/java/run/endive/runtime/WasmArray.java
@@ -17,7 +17,7 @@ public final class WasmArray implements WasmGcRef {
     /**
      * @deprecated use {@link #builder()}
      */
-    @Deprecated(since = "use builder()")
+    @Deprecated
     public WasmArray(int typeIdx, long[] elements) {
         this(typeIdx, elements, null);
     }
@@ -25,7 +25,7 @@ public final class WasmArray implements WasmGcRef {
     /**
      * @deprecated use {@link #builder()}
      */
-    @Deprecated(since = "use builder()")
+    @Deprecated
     public WasmArray(int typeIdx, long[] elements, Object[] elementRefs) {
         this.typeIdx = typeIdx;
         this.elements = elements;

--- a/runtime/src/main/java/run/endive/runtime/WasmException.java
+++ b/runtime/src/main/java/run/endive/runtime/WasmException.java
@@ -22,7 +22,7 @@ public class WasmException extends RuntimeException {
     /**
      * @deprecated use {@link #builder()}
      */
-    @Deprecated(since = "use builder()")
+    @Deprecated
     public WasmException(Instance instance, int tagIdx, long[] args) {
         this(instance, tagIdx, args.clone(), null);
     }

--- a/runtime/src/main/java/run/endive/runtime/WasmStruct.java
+++ b/runtime/src/main/java/run/endive/runtime/WasmStruct.java
@@ -17,7 +17,7 @@ public final class WasmStruct implements WasmGcRef {
     /**
      * @deprecated use {@link #builder()}
      */
-    @Deprecated(since = "use builder()")
+    @Deprecated
     public WasmStruct(int typeIdx, long[] fields) {
         this(typeIdx, fields, null);
     }
@@ -25,7 +25,7 @@ public final class WasmStruct implements WasmGcRef {
     /**
      * @deprecated use {@link #builder()}
      */
-    @Deprecated(since = "use builder()")
+    @Deprecated
     public WasmStruct(int typeIdx, long[] fields, Object[] fieldRefs) {
         this.typeIdx = typeIdx;
         this.fields = fields;

--- a/wasm/src/main/java/run/endive/wasm/types/Global.java
+++ b/wasm/src/main/java/run/endive/wasm/types/Global.java
@@ -20,7 +20,7 @@ public final class Global {
     /**
      * @deprecated use {@link #Global(ValType, MutabilityType, List)}
      */
-    @Deprecated(since = "1.3.0")
+    @Deprecated
     public Global(ValueType valueType, MutabilityType mutabilityType, List<Instruction> init) {
         this.valType = valueType.toValType();
         this.mutabilityType = mutabilityType;

--- a/wasm/src/main/java/run/endive/wasm/types/GlobalImport.java
+++ b/wasm/src/main/java/run/endive/wasm/types/GlobalImport.java
@@ -27,7 +27,7 @@ public final class GlobalImport extends Import {
     /**
      * @deprecated use {@link #GlobalImport(String, String, MutabilityType, ValType)}
      */
-    @Deprecated(since = "1.3.0")
+    @Deprecated
     public GlobalImport(
             String moduleName, String name, MutabilityType mutabilityType, ValueType type) {
         super(moduleName, name);

--- a/wasm/src/main/java/run/endive/wasm/types/Table.java
+++ b/wasm/src/main/java/run/endive/wasm/types/Table.java
@@ -18,7 +18,7 @@ public class Table {
     /**
      * @deprecated use {@link #Table(ValType, TableLimits)}
      */
-    @Deprecated(since = "1.3.0")
+    @Deprecated
     public Table(ValueType elementType, TableLimits limits) {
         this(
                 elementType.toValType(),

--- a/wasm/src/main/java/run/endive/wasm/types/TableImport.java
+++ b/wasm/src/main/java/run/endive/wasm/types/TableImport.java
@@ -26,7 +26,7 @@ public final class TableImport extends Import {
     /**
      * @deprecated use {@link #TableImport(String, String, ValType, TableLimits)}
      */
-    @Deprecated(since = "1.3.0")
+    @Deprecated
     public TableImport(String moduleName, String name, ValueType entryType, TableLimits limits) {
         super(moduleName, name);
         this.entryType = Objects.requireNonNull(entryType, "entryType").toValType();

--- a/wasm/src/main/java/run/endive/wasm/types/ValType.java
+++ b/wasm/src/main/java/run/endive/wasm/types/ValType.java
@@ -801,7 +801,10 @@ public final class ValType {
             return false;
         }
 
-        @Deprecated(since = "use .build.resolve(typeSection) instead")
+        /**
+         * @deprecated use {@code .build().resolve(typeSection)} instead
+         */
+        @Deprecated
         public ValType build(Function<Integer, FunctionType> context) {
             if (!isValidOpcode(opcode)) {
                 throw new WasmEngineException("Invalid type opcode: " + opcode);
@@ -834,7 +837,10 @@ public final class ValType {
                             : -1);
         }
 
-        @Deprecated(since = "use .build.resolve(typeSection) instead")
+        /**
+         * @deprecated use {@code .build().resolve(typeSection)} instead
+         */
+        @Deprecated
         public FunctionType substitute(
                 int opcode, int typeIdx, Function<Integer, FunctionType> context) {
             if (ValType.isReference(opcode) && typeIdx >= 0) {

--- a/wasm/src/main/java/run/endive/wasm/types/Value.java
+++ b/wasm/src/main/java/run/endive/wasm/types/Value.java
@@ -120,7 +120,7 @@ public class Value {
     /**
      * @deprecated use {@link #Value(ValType, long)}
      */
-    @Deprecated(since = "1.3.0")
+    @Deprecated
     public Value(ValueType type, long value) {
         this.type = requireNonNull(type, "type").toValType();
         data = value;

--- a/wasm/src/main/java/run/endive/wasm/types/ValueType.java
+++ b/wasm/src/main/java/run/endive/wasm/types/ValueType.java
@@ -6,7 +6,7 @@ import run.endive.wasm.MalformedException;
 /**
  * @deprecated use {@link run.endive.wasm.types.ValType}
  */
-@Deprecated(since = "1.3.0")
+@Deprecated
 public enum ValueType {
     UNKNOWN(-1),
     F64(ID.F64),


### PR DESCRIPTION
Resolves #104

- Remove values which contained a message instead of a version
- Remove versions which refer to Chicory versioning; Endive started at 0.0.1 again