### PR TITLE
Replace deprecated Docusaurus config value

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -19,7 +19,11 @@ const config: Config = {
   projectName: 'endive', // Usually your repo name.
 
   onBrokenLinks: 'warn', // TODO: fixme when everything is ready: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
+  },
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you


### PR DESCRIPTION
See https://docusaurus.io/docs/api/docusaurus-config#onBrokenMarkdownLinks
Was previously causing a warning when building:
> [WARNING] The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4.
> Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.

Side note: I think this config and `onBrokenLinks` could be set to `'throw'` now if desired. There seem to be currently no broken inter-doc links.