### PR TITLE
Upgrade wasm-tools to v1.246.0

### DIFF
--- a/wasm-tools/pom.xml
+++ b/wasm-tools/pom.xml
@@ -14,7 +14,7 @@
   <description>wasm tools compiled to pure Java with Endive</description>
 
   <properties>
-    <wasm-tools.version>1.240.0</wasm-tools.version>
+    <wasm-tools.version>1.246.0</wasm-tools.version>
   </properties>
 
   <dependencies>
@@ -102,11 +102,10 @@
               <wasmFile>${project.basedir}/target/wasm-tools.wasm</wasmFile>
               <!-- <interpreterFallback>WARN</interpreterFallback> -->
               <interpretedFunctions>
-                <function>4725</function>
-                <function>5095</function>
-                <function>5422</function>
-                <function>7668</function>
-                <function>10543</function>
+                <function>5210</function>
+                <function>5217</function>
+                <function>5887</function>
+                <function>8116</function>
               </interpretedFunctions>
             </configuration>
           </execution>


### PR DESCRIPTION
Version 1.240.0 of wasm-tools fails to execute `json-from-wast` on the [wasmtime/types.wast](https://github.com/WebAssembly/component-model/blob/main/test/wasmtime/types.wast) test from the Component Model spec, which I was trying to execute for work on the ABI in [endive-cm](https://github.com/roastedroot/endive-cm).

I'm unaware of any specific reason why the wasm-tools dependency hasn't been updated in a little bit, so here is an update to the latest release, v1.246.0.