### PR TITLE
Replace `assert` statements used for argument validation

### DIFF
--- a/build-time-compiler/src/main/java/run/endive/build/time/compiler/Generator.java
+++ b/build-time-compiler/src/main/java/run/endive/build/time/compiler/Generator.java
@@ -40,6 +40,7 @@ import run.endive.compiler.internal.Compiler;
 import run.endive.runtime.CompiledModule;
 import run.endive.runtime.Instance;
 import run.endive.runtime.Machine;
+import run.endive.wasm.MalformedException;
 import run.endive.wasm.Parser;
 import run.endive.wasm.WasmModule;
 import run.endive.wasm.WasmWriter;
@@ -156,7 +157,7 @@ public class Generator {
                         writeVarUInt32(out, count);
                         var actual = readVarUInt32(source);
                         if (count != actual) {
-                            throw new RuntimeException("wrong number of function bodies");
+                            throw new MalformedException("wrong number of function bodies");
                         }
                         for (int i = 0; i < count; i++) {
                             var funcId = importFuncs + i;
@@ -180,7 +181,8 @@ public class Generator {
                                 source.position(source.position() + bodySize - 1);
                                 var end_op = source.get();
                                 if (end_op != OpCode.END.opcode()) {
-                                    throw new RuntimeException("unexpected end opcode: " + end_op);
+                                    throw new MalformedException(
+                                            "unexpected end opcode: " + end_op);
                                 }
 
                                 // Write an empty function body

--- a/build-time-compiler/src/main/java/run/endive/build/time/compiler/Generator.java
+++ b/build-time-compiler/src/main/java/run/endive/build/time/compiler/Generator.java
@@ -155,7 +155,9 @@ public class Generator {
                         int count = module.codeSection().functionBodyCount();
                         writeVarUInt32(out, count);
                         var actual = readVarUInt32(source);
-                        assert count == actual;
+                        if (count != actual) {
+                            throw new RuntimeException("wrong number of function bodies");
+                        }
                         for (int i = 0; i < count; i++) {
                             var funcId = importFuncs + i;
                             if (interpretedFunctions.contains(funcId)) {
@@ -177,7 +179,9 @@ public class Generator {
                                 var bodySize = (int) readVarUInt32(source);
                                 source.position(source.position() + bodySize - 1);
                                 var end_op = source.get();
-                                assert end_op == OpCode.END.opcode();
+                                if (end_op != OpCode.END.opcode()) {
+                                    throw new RuntimeException("unexpected end opcode: " + end_op);
+                                }
 
                                 // Write an empty function body
                                 writeVarUInt32(out, 3); // function size in bytes

--- a/compiler/src/main/java/run/endive/compiler/internal/Emitters.java
+++ b/compiler/src/main/java/run/endive/compiler/internal/Emitters.java
@@ -38,6 +38,7 @@ import org.objectweb.asm.commons.InstructionAdapter;
 import run.endive.runtime.Instance;
 import run.endive.runtime.OpCodeIdentifier;
 import run.endive.runtime.WasmException;
+import run.endive.wasm.WasmEngineException;
 import run.endive.wasm.WasmModule;
 import run.endive.wasm.types.FunctionType;
 import run.endive.wasm.types.ValType;
@@ -104,13 +105,15 @@ final class Emitters {
     }
 
     private static void assertTempSlotInRange(Context ctx, int slotsNeeded) {
-        assert ctx.tempSlot() + slotsNeeded <= ctx.trySaveBaseSlot()
-                : "temp slot overflow: need "
-                        + slotsNeeded
-                        + " slots at "
-                        + ctx.tempSlot()
-                        + " but try-save starts at "
-                        + ctx.trySaveBaseSlot();
+        if (ctx.tempSlot() + slotsNeeded > ctx.trySaveBaseSlot()) {
+            throw new WasmEngineException(
+                    "temp slot overflow: need "
+                            + slotsNeeded
+                            + " slots at "
+                            + ctx.tempSlot()
+                            + " but try-save starts at "
+                            + ctx.trySaveBaseSlot());
+        }
     }
 
     /**

--- a/runtime/src/main/java/run/endive/runtime/GlobalInstance.java
+++ b/runtime/src/main/java/run/endive/runtime/GlobalInstance.java
@@ -89,7 +89,10 @@ public class GlobalInstance {
     }
 
     public void setValue(Value value) {
-        assert (value.type() == valType);
+        if (value.type() != valType) {
+            throw new IllegalArgumentException(
+                    "Value has wrong type; expected " + valType + " got " + value.type());
+        }
         this.valueLow = value.raw();
     }
 

--- a/runtime/src/main/java/run/endive/runtime/Instance.java
+++ b/runtime/src/main/java/run/endive/runtime/Instance.java
@@ -1072,6 +1072,15 @@ public class Instance implements AutoCloseable {
             return exports;
         }
 
+        /**
+         * Builds the instance.
+         *
+         * <p>When running in 'runtime compilation' mode, invalid or unsupported Wasm code might already cause an
+         * exception when calling this method. For 'interpreter' mode such exceptions might instead occur during
+         * execution of the Wasm code.
+         *
+         * @throws RuntimeException if the Wasm code is invalid or contains unsupported instructions
+         */
         public Instance build() {
             Map<String, Export> exports = genExports(module.exportSection());
             var globalInitializers = module.globalSection().globals();

--- a/runtime/src/main/java/run/endive/runtime/Instance.java
+++ b/runtime/src/main/java/run/endive/runtime/Instance.java
@@ -1072,15 +1072,6 @@ public class Instance implements AutoCloseable {
             return exports;
         }
 
-        /**
-         * Builds the instance.
-         *
-         * <p>When running in 'runtime compilation' mode, invalid or unsupported Wasm code might already cause an
-         * exception when calling this method. For 'interpreter' mode such exceptions might instead occur during
-         * execution of the Wasm code.
-         *
-         * @throws RuntimeException if the Wasm code is invalid or contains unsupported instructions
-         */
         public Instance build() {
             Map<String, Export> exports = genExports(module.exportSection());
             var globalInitializers = module.globalSection().globals();

--- a/runtime/src/main/java/run/endive/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/run/endive/runtime/InterpreterMachine.java
@@ -3215,7 +3215,7 @@ public class InterpreterMachine implements Machine {
                 frame = callStack.peek(); // peek, don't pop - keep catcher on callStack
             }
         }
-        throw new RuntimeException("unreacheable");
+        throw new RuntimeException("unreachable");
     }
 
     private static void BLOCK(

--- a/runtime/src/main/java/run/endive/runtime/OpcodeImpl.java
+++ b/runtime/src/main/java/run/endive/runtime/OpcodeImpl.java
@@ -917,9 +917,12 @@ public final class OpcodeImpl {
             impl = java.lang.invoke.VarHandle::fullFence;
         } catch (NoSuchMethodError e) {
             try {
-                // Suppress IntelliJ warning about module-info.java needing `requires jdk.unsupported` for
-                // `sun.misc.Unsafe`. This code here is only a fallback when `VarHandle::fullFence` is unavailable,
-                // which is only the case for Java < 9 (and therefore module-info.java is irrelevant).
+                // Suppress IntelliJ warning about module-info.java needing `requires
+                // jdk.unsupported` for
+                // `sun.misc.Unsafe`. This code here is only a fallback when `VarHandle::fullFence`
+                // is unavailable,
+                // which is only the case for Java < 9 (and therefore module-info.java is
+                // irrelevant).
                 @SuppressWarnings("Java9ReflectionClassVisibility")
                 Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
                 var theUnsafeField = unsafeClass.getDeclaredField("theUnsafe");

--- a/wasm/src/main/java/run/endive/wasm/Parser.java
+++ b/wasm/src/main/java/run/endive/wasm/Parser.java
@@ -95,6 +95,8 @@ import run.endive.wasm.types.Value;
 
 /**
  * Parser for Web Assembly binaries.
+ *
+ * <p>If parsing fails, a {@link RuntimeException} or any subtype of it might be thrown.
  */
 @SuppressWarnings("UnnecessaryCodeBlock")
 public final class Parser {
@@ -785,7 +787,9 @@ public final class Parser {
             var firstByte = (int) readVarUInt32(buffer);
             if (firstByte == 0x40) {
                 var secondByte = readVarUInt32(buffer);
-                assert secondByte == 0x00;
+                if (secondByte != 0x00) {
+                    throw new MalformedException("incorrect second byte");
+                }
                 var tableType = readValueType(buffer, typeSection);
                 var limits = readTableLimits(buffer);
                 var init = parseExpression(buffer);

--- a/wasm/src/main/java/run/endive/wasm/Parser.java
+++ b/wasm/src/main/java/run/endive/wasm/Parser.java
@@ -95,8 +95,6 @@ import run.endive.wasm.types.Value;
 
 /**
  * Parser for Web Assembly binaries.
- *
- * <p>If parsing fails, a {@link RuntimeException} or any subtype of it might be thrown.
  */
 @SuppressWarnings("UnnecessaryCodeBlock")
 public final class Parser {

--- a/wasm/src/main/java/run/endive/wasm/Validator.java
+++ b/wasm/src/main/java/run/endive/wasm/Validator.java
@@ -1033,7 +1033,9 @@ final class Validator {
                         }
                         var type = module.typeSection().getType(getTagType(tagNumber).typeIdx());
                         popVals(type.params());
-                        assert (type.returns().size() == 0);
+                        if (!type.returns().isEmpty()) {
+                            throw new InvalidException("expected no returns");
+                        }
                         unreachable();
                         break;
                     }

--- a/wasm/src/main/java/run/endive/wasm/types/AnnotatedInstruction.java
+++ b/wasm/src/main/java/run/endive/wasm/types/AnnotatedInstruction.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
-
 import run.endive.wasm.InvalidException;
 
 /*

--- a/wasm/src/main/java/run/endive/wasm/types/AnnotatedInstruction.java
+++ b/wasm/src/main/java/run/endive/wasm/types/AnnotatedInstruction.java
@@ -156,10 +156,14 @@ public final class AnnotatedInstruction extends Instruction {
                 case END:
                 case IF:
                 case TRY_TABLE:
-                    assert (scope.isPresent());
+                    if (scope.isEmpty()) {
+                        throw new InvalidException("unknown scope");
+                    }
                     break;
                 default:
-                    assert (scope.isEmpty());
+                    if (scope.isPresent()) {
+                        throw new InvalidException("scope is not empty");
+                    }
                     break;
             }
             switch (base.opcode()) {
@@ -180,8 +184,9 @@ public final class AnnotatedInstruction extends Instruction {
                     }
                     break;
                 default:
-                    assert (labelTrue.isEmpty());
-                    assert (labelFalse.isEmpty());
+                    if (!(labelTrue.isEmpty() && labelFalse.isEmpty())) {
+                        throw new InvalidException("labels are not empty");
+                    }
                     break;
             }
             switch (base.opcode()) {
@@ -191,7 +196,9 @@ public final class AnnotatedInstruction extends Instruction {
                     }
                     break;
                 default:
-                    assert (labelTable.isEmpty());
+                    if (labelTable.isPresent()) {
+                        throw new InvalidException("label table is not empty");
+                    }
                     break;
             }
             switch (base.opcode()) {
@@ -201,7 +208,9 @@ public final class AnnotatedInstruction extends Instruction {
                     }
                     break;
                 default:
-                    assert (catches.isEmpty());
+                    if (catches.isPresent()) {
+                        throw new InvalidException("catches is not empty");
+                    }
                     break;
             }
 

--- a/wasm/src/main/java/run/endive/wasm/types/CatchOpCode.java
+++ b/wasm/src/main/java/run/endive/wasm/types/CatchOpCode.java
@@ -3,6 +3,7 @@ package run.endive.wasm.types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import run.endive.wasm.WasmEngineException;
 
 public enum CatchOpCode {
     CATCH(0x00),
@@ -98,7 +99,9 @@ public enum CatchOpCode {
                     }
             }
         }
-        assert (result.size() == length);
+        if (result.size() != length) {
+            throw new WasmEngineException("wrong result size");
+        }
         return result;
     }
 

--- a/wasm/src/main/java/run/endive/wasm/types/NameCustomSection.java
+++ b/wasm/src/main/java/run/endive/wasm/types/NameCustomSection.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.ToIntFunction;
+import run.endive.wasm.WasmEngineException;
 
 /**
  * The "name" custom section.
@@ -74,7 +75,9 @@ public final class NameCustomSection extends CustomSection {
             // todo: IDs 4 and 10 are reserved for the Host GC spec
             switch (id) {
                 case 0:
-                    assert (moduleName == null);
+                    if (moduleName != null) {
+                        throw new WasmEngineException("duplicate module name");
+                    }
                     moduleName = readName(slice);
                     break;
                 case 1:

--- a/wasm/src/main/java/run/endive/wasm/types/RecType.java
+++ b/wasm/src/main/java/run/endive/wasm/types/RecType.java
@@ -21,7 +21,9 @@ public final class RecType {
     }
 
     public FunctionType legacy() {
-        assert subTypes.length == 1;
+        if (!isLegacy()) {
+            throw new IllegalStateException("type is not legacy");
+        }
         return subTypes[0].compType().funcType();
     }
 

--- a/wasm/src/main/java/run/endive/wasm/types/Value.java
+++ b/wasm/src/main/java/run/endive/wasm/types/Value.java
@@ -65,23 +65,30 @@ public class Value {
         return Value.f32(floatToLong(data));
     }
 
+    private void expectType(ValType expected) {
+        if (type != expected) {
+            throw new IllegalStateException(
+                    "Expected value to have type " + expected + " but is " + type);
+        }
+    }
+
     public int asInt() {
-        assert (type == ValType.I32);
+        expectType(ValType.I32);
         return (int) data;
     }
 
     public long asLong() {
-        assert (type == ValType.I64);
+        expectType(ValType.I64);
         return data;
     }
 
     public float asFloat() {
-        assert (type == ValType.F32);
+        expectType(ValType.F32);
         return longToFloat(data);
     }
 
     public double asDouble() {
-        assert (type == ValType.F64);
+        expectType(ValType.F64);
         return longToDouble(data);
     }
 
@@ -332,7 +339,7 @@ public class Value {
             case ValType.ID.RefNull:
                 return "refnull[" + (int) data + "]";
             default:
-                throw new AssertionError("Unhandled type: " + type);
+                throw new RuntimeException("Unhandled type: " + type);
         }
     }
 

--- a/wasm/src/main/java/run/endive/wasm/types/Value.java
+++ b/wasm/src/main/java/run/endive/wasm/types/Value.java
@@ -339,7 +339,7 @@ public class Value {
             case ValType.ID.RefNull:
                 return "refnull[" + (int) data + "]";
             default:
-                throw new RuntimeException("Unhandled type: " + type);
+                return data + "@" + type;
         }
     }
 

--- a/wasm/src/test/java/run/endive/wasm/types/ValTypeTest.java
+++ b/wasm/src/test/java/run/endive/wasm/types/ValTypeTest.java
@@ -33,7 +33,7 @@ public class ValTypeTest {
         for (var vt : cases) {
             long id = vt.id();
             ValType roundTrip = ValType.builder().fromId(id).build();
-            assert vt.equals(roundTrip) : "Failed to roundtrip: " + vt;
+            assertEquals(vt, roundTrip);
         }
     }
 


### PR DESCRIPTION
Instead of an `Exception` they cause an `AssertionError` (an `Error`), or worse when assertions are disabled at runtime execution just continues despite the program being in an invalid state.

Some of these were found during the fuzzing of #98.

This does not replace all `assert` calls. To me it looks like the remaining ones are not actually used for argument / state validation.