### PR TITLE
Use `./mvnw` for CI workflows

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -26,7 +26,7 @@ jobs:
         # Use maven cache. Gradle's caching is controlled by its own action.
         cache: maven
     - name: Prepare local repo for the tests
-      run: mvn -B -Dandroid-prepare
+      run: ./mvnw -B -Dandroid-prepare
     # Setup Gradle. Cache will be readonly except for the main branch.
     # see: https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#using-the-cache-read-only
     - name: Setup Gradle

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
           java-version: '${{ matrix.version }}'
           cache: maven
       - name: Test Java
-        run: mvn -B clean install
+        run: ./mvnw -B clean install
         env:
           MAVEN_OPTS: "-ea"
 

--- a/.github/workflows/dependency-check.yaml
+++ b/.github/workflows/dependency-check.yaml
@@ -23,7 +23,7 @@ jobs:
           java-version: '21'
           cache: maven
       - name: Build
-        run: mvn -B -Dquickly
+        run: ./mvnw -B -Dquickly
       - name: Cache dependency-check data
         uses: actions/cache@v6
         with:
@@ -33,7 +33,7 @@ jobs:
             dependency-check-data-
       - name: Run OWASP Dependency Check
         run: |
-          mvn -B org.owasp:dependency-check-maven:check \
+          ./mvnw -B org.owasp:dependency-check-maven:check \
             -DfailBuildOnCVSS=7 \
             -DsuppressedPaths=./dependency-check-suppressions.xml \
             -Dformats=HTML,JSON \

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -25,9 +25,9 @@ jobs:
         if: github.repository_owner == 'bytecodealliance'
         run: |
           # Build everything
-          mvn -B -Dquickly
+          ./mvnw -B -Dquickly
           # Run differential fuzz tests (interpreter vs compiler)
-          mvn -B verify -pl fuzz -DskipTests=false -Dfuzz.test.iterations=50
+          ./mvnw -B verify -pl fuzz -DskipTests=false -Dfuzz.test.iterations=50
 
       - name: Upload crash reproducers
         uses: actions/upload-artifact@v7

--- a/.github/workflows/redline.yaml
+++ b/.github/workflows/redline.yaml
@@ -36,6 +36,6 @@ jobs:
         working-directory: redline/wasm-build
         run: make all
       - name: Build and test redline
-        run: mvn -B clean install -Predline
+        run: ./mvnw -B clean install -Predline
         env:
           MAVEN_OPTS: "-ea"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
         run: make all
 
       - name: Compile
-        run: mvn --batch-mode -Dquickly -Predline
+        run: ./mvnw --batch-mode -Dquickly -Predline
 
       - name: Setup Git
         run: |
@@ -62,7 +62,7 @@ jobs:
 
       - name: Set the version
         run: |
-          mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release-version }} -Predline
+          ./mvnw versions:set -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release-version }} -Predline
           git add .
           git commit -m "Release version update ${{ github.event.inputs.release-version }}"
           git push
@@ -74,8 +74,8 @@ jobs:
       - name: Release to Maven Central
         run: |
           # -Dquickly is needed to locally publish wasm-corpus
-          mvn --batch-mode -Dquickly -Predline
-          mvn --batch-mode clean deploy -Drelease -Predline -DskipTests=true -X
+          ./mvnw --batch-mode -Dquickly -Predline
+          ./mvnw --batch-mode clean deploy -Drelease -Predline -DskipTests=true -X
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.SONATYPE_PASSWORD }}
@@ -83,7 +83,7 @@ jobs:
 
       - name: Back to Snapshot
         run: |
-          mvn versions:set -DgenerateBackupPoms=false -DnewVersion=999-SNAPSHOT -Predline
+          ./mvnw versions:set -DgenerateBackupPoms=false -DnewVersion=999-SNAPSHOT -Predline
           git add .
           git commit -m "Snapshot version update"
           git push

--- a/.github/workflows/zig-testsuite.yaml
+++ b/.github/workflows/zig-testsuite.yaml
@@ -27,6 +27,6 @@ jobs:
         if: github.repository_owner == 'bytecodealliance'
         run: |
           # Build everything
-          mvn -B -Dquickly
+          ./mvnw -B -Dquickly
           # Run only the ZigTestsuite
-          mvn -B test -f nightly-testsuite/pom.xml
+          ./mvnw -B test -f nightly-testsuite/pom.xml


### PR DESCRIPTION
To make builds consistent and not use whatever Maven version the GitHub runner has pre-installed.

I hope this does not break anything, especially for the workflows which are not run for PRs (e.g. release workflow).