### PR TITLE
Improve documentation for memory and table `grow` methods

### DIFF
--- a/runtime/src/main/java/run/endive/runtime/ByteArrayMemory.java
+++ b/runtime/src/main/java/run/endive/runtime/ByteArrayMemory.java
@@ -22,12 +22,14 @@ import run.endive.wasm.types.PassiveDataSegment;
 
 /**
  * Represents the linear memory in the Wasm program. Can be shared
- * reference b/w the host and the guest.
+ * reference between the host and the guest.
  *
- * try-catch is faster than explicit checks and can be optimized by the JVM.
- * Catching generic RuntimeException to keep the method bodies short and easily inlinable.
+ * <p>This is the recommended memory implementation for recent OpenJDK systems.
  */
 public final class ByteArrayMemory implements Memory {
+    // Implementation note: try-catch is faster than explicit checks and can be optimized by the
+    // JVM. Catching generic RuntimeException to keep the method bodies short and easily inlinable.
+
     // get access to the byte array elements viewed as if it were
     // a different primitive array type, such as int[], long[], etc.
     // This is actually the fastest way to access and reinterpret the underlying bytes.

--- a/runtime/src/main/java/run/endive/runtime/ByteBufferMemory.java
+++ b/runtime/src/main/java/run/endive/runtime/ByteBufferMemory.java
@@ -23,9 +23,9 @@ import run.endive.wasm.types.PassiveDataSegment;
 
 /**
  * Represents the linear memory in the Wasm program. Can be shared
- * reference b/w the host and the guest.
+ * reference between the host and the guest.
  *
- * This is the preferred memory implementation on Android systems.
+ * <p>This is the preferred memory implementation on Android systems.
  */
 public final class ByteBufferMemory implements Memory {
     // Package private for usage as default impl. in Memory. Can become private in next major

--- a/runtime/src/main/java/run/endive/runtime/Memory.java
+++ b/runtime/src/main/java/run/endive/runtime/Memory.java
@@ -24,6 +24,11 @@ public interface Memory {
 
     int pages();
 
+    /**
+     * Tries to grow the memory by the specified additional size (in pages).
+     *
+     * @return the previous size (in pages), or -1 on error
+     */
     int grow(int size);
 
     int initialPages();

--- a/runtime/src/main/java/run/endive/runtime/TableInstance.java
+++ b/runtime/src/main/java/run/endive/runtime/TableInstance.java
@@ -8,6 +8,7 @@ import run.endive.wasm.WasmEngineException;
 import run.endive.wasm.types.Table;
 import run.endive.wasm.types.TableLimits;
 import run.endive.wasm.types.ValType;
+import run.endive.wasm.types.Value;
 
 public class TableInstance {
 
@@ -42,6 +43,14 @@ public class TableInstance {
         return table.limits();
     }
 
+    /**
+     * Tries to grow the table by the specified additional size.
+     *
+     * <p>New refs use {@code value} as initial value; new object refs (in case this is a GC table) remain {@code null}.
+     *
+     * @param value the value to use for the newly created ref entries
+     * @return the previous size, or -1 on error
+     */
     public int grow(int size, int value, Instance instance) {
         var oldSize = refs.length;
         var targetSize = oldSize + size;
@@ -61,6 +70,14 @@ public class TableInstance {
         return oldSize;
     }
 
+    /**
+     * Tries to grow the table by the specified additional size.
+     *
+     * <p>New refs use {@link Value#REF_NULL_VALUE} as initial value; new object refs use the {@code refValue} argument.
+     *
+     * @param refValue the value to use for the newly created object ref entries
+     * @return the previous size, or -1 on error
+     */
     public int growWithRef(int size, Object refValue, Instance instance) {
         var oldSize = refs.length;
         var targetSize = oldSize + size;


### PR DESCRIPTION
I think especially the "return -1 on error" is an important aspect to document.

Side note: The [JavaScript API](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/JavaScript_interface/Memory/grow) seems to throw an exception for errors. Though I understand that the Endive implementation here is used both as API and as implementation for the Wasm opcode (which requires -1 on error). Not sure how often these `grow` methods are used from the API by users, but maybe it would make sense then in the future to consider refactoring it to throw an error by default instead of using -1 as return value (respectively having a `tryGrow` which returns -1)?