### PR TITLE
Deduplicate obtaining `ATOMIC_FENCE_IMPL`

### DIFF
--- a/runtime/src/main/java/run/endive/runtime/ByteBufferMemory.java
+++ b/runtime/src/main/java/run/endive/runtime/ByteBufferMemory.java
@@ -3,7 +3,6 @@ package run.endive.runtime;
 import static java.lang.Math.min;
 import static run.endive.runtime.ConstantEvaluators.computeConstantValue;
 
-import java.lang.reflect.InvocationTargetException;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
@@ -28,10 +27,6 @@ import run.endive.wasm.types.PassiveDataSegment;
  * This is the preferred memory implementation on Android systems.
  */
 public final class ByteBufferMemory implements Memory {
-    // Package private for usage as default impl. in Memory. Can become private in next major
-    // release.
-    static final Runnable ATOMIC_FENCE_IMPL = getAtomicFenceImpl();
-
     // Page addressing constants
     private static final int PAGE_SHIFT = 16; // PAGE_SIZE = 65536 = 2^16
     private static final int PAGE_MASK = PAGE_SIZE - 1;
@@ -684,36 +679,5 @@ public final class ByteBufferMemory implements Memory {
     @Override
     public void drop(int segment) {
         dataSegments[segment] = PassiveDataSegment.EMPTY;
-    }
-
-    private static Runnable getAtomicFenceImpl() {
-        try {
-            // to take into account older Android API level:
-            // https://developer.android.com/reference/java/lang/invoke/VarHandle#fullFence()
-            java.lang.invoke.VarHandle.fullFence();
-            return java.lang.invoke.VarHandle::fullFence;
-        } catch (NoSuchMethodError e) {
-            try {
-                Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
-                var theUnsafeField = unsafeClass.getDeclaredField("theUnsafe");
-                theUnsafeField.setAccessible(true);
-                var theUnsafe = theUnsafeField.get(null);
-                var fullFence = unsafeClass.getMethod("fullFence");
-
-                return () -> {
-                    try {
-                        fullFence.invoke(theUnsafe);
-                    } catch (IllegalAccessException | InvocationTargetException ex) {
-                        throw new RuntimeException(
-                                "ATOMIC_FENCE implementation: Failed to invoke"
-                                        + " sun.misc.Unsafe",
-                                ex);
-                    }
-                };
-            } catch (Throwable ex) {
-                throw new RuntimeException(
-                        "ATOMIC_FENCE implementation: Failed to lookup sun.misc.Unsafe", ex);
-            }
-        }
     }
 }

--- a/runtime/src/main/java/run/endive/runtime/Memory.java
+++ b/runtime/src/main/java/run/endive/runtime/Memory.java
@@ -50,7 +50,7 @@ public interface Memory {
     ///////////////////////////
 
     default void atomicFence() {
-        ByteBufferMemory.ATOMIC_FENCE_IMPL.run();
+        OpcodeImpl.ATOMIC_FENCE();
     }
 
     default int atomicWait(int addr, int expected, long timeout) {

--- a/runtime/src/main/java/run/endive/runtime/OpcodeImpl.java
+++ b/runtime/src/main/java/run/endive/runtime/OpcodeImpl.java
@@ -917,6 +917,10 @@ public final class OpcodeImpl {
             impl = java.lang.invoke.VarHandle::fullFence;
         } catch (NoSuchMethodError e) {
             try {
+                // Suppress IntelliJ warning about module-info.java needing `requires jdk.unsupported` for
+                // `sun.misc.Unsafe`. This code here is only a fallback when `VarHandle::fullFence` is unavailable,
+                // which is only the case for Java < 9 (and therefore module-info.java is irrelevant).
+                @SuppressWarnings("Java9ReflectionClassVisibility")
                 Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
                 var theUnsafeField = unsafeClass.getDeclaredField("theUnsafe");
                 theUnsafeField.setAccessible(true);


### PR DESCRIPTION
It seems the code in `ByteBufferMemory` and `OpcodeImpl` is equivalent.

Or was the reason for this that the opcode and the memory method just happen to be identical, and therefore should be separate? If you want I could add a comment to `Memory#atomicFence()` then.