### PR TITLE
Fix some non-bug IntelliJ warnings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,6 @@ But first, read this page (including the small print at the end).
   + [Coding Guidelines](#coding-guidelines)
   + [Continuous Integration](#continuous-integration)
   + [Tests and documentation are not optional](#tests-and-documentation-are-not-optional)
-  + [Current status](#current-status)
 * [Reporting an issue](#reporting-an-issue)
 * [AI Tool Use Policy](#ai-tool-use-policy)
 * [Legal](#legal)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <picture>
-    <img width="200" src="endive.png">
+    <img width="200" src="endive.png" alt="Endive logo">
   </picture>
   <br>
   <strong>A <a href="https://bytecodealliance.org/">Bytecode Alliance</a> hosted project</strong>

--- a/cli/src/main/java/run/endive/experimental/cli/Cli.java
+++ b/cli/src/main/java/run/endive/experimental/cli/Cli.java
@@ -80,7 +80,7 @@ public class Cli implements Runnable {
             var export = instance.export(functionName);
             var params = new long[type.params().size()];
             for (var i = 0; i < type.params().size(); i++) {
-                params[i] = Long.valueOf(arguments[i]);
+                params[i] = arguments[i];
             }
 
             var result = export.apply(params);

--- a/codegen/src/main/java/run/endive/codegen/ModuleInterfaceCodegen.java
+++ b/codegen/src/main/java/run/endive/codegen/ModuleInterfaceCodegen.java
@@ -299,7 +299,7 @@ public final class ModuleInterfaceCodegen {
                                 "applyWithRefs",
                                 NodeList.nodeList(longArrayExpr, refArrayExpr));
 
-                if (exportType.returns().size() == 0) {
+                if (exportType.returns().isEmpty()) {
                     exportMethod.setType(void.class);
                     methodBody.addStatement(applyWithRefsCall);
                     methodBody.addStatement(new ReturnStmt());
@@ -352,7 +352,7 @@ public final class ModuleInterfaceCodegen {
                         new MethodCallExpr(
                                 exportFieldName, "apply", NodeList.nodeList(handleCallArguments));
 
-                if (exportType.returns().size() == 0) {
+                if (exportType.returns().isEmpty()) {
                     exportMethod.setType(void.class);
                     methodBody.addStatement(exportApplyHandle).addStatement(new ReturnStmt());
                 } else if (exportType.returns().size() > 1) {
@@ -400,7 +400,7 @@ public final class ModuleInterfaceCodegen {
                         });
             }
 
-            if (importedModules.size() > 0) {
+            if (!importedModules.isEmpty()) {
                 var toImportValuesBody = new BlockStmt();
                 toImportValuesBody.addStatement(
                         new AssignExpr(
@@ -552,7 +552,7 @@ public final class ModuleInterfaceCodegen {
                             importsCu.addImport("run.endive.runtime.WasmFunctionHandle");
 
                             // Set interface method return type
-                            if (importType.returns().size() == 0) {
+                            if (importType.returns().isEmpty()) {
                                 importMethod.setType(void.class);
                             } else if (importType.returns().size() == 1) {
                                 importMethod.setType(
@@ -564,7 +564,7 @@ public final class ModuleInterfaceCodegen {
 
                             // Build applyWithRefs body
                             var refsBody = new BlockStmt();
-                            if (importType.returns().size() == 0) {
+                            if (importType.returns().isEmpty()) {
                                 refsBody.addStatement(importApplyHandle);
                                 refsBody.addStatement(
                                         new ReturnStmt(
@@ -639,7 +639,7 @@ public final class ModuleInterfaceCodegen {
                             // No object refs - use original lambda path
                             var functionBodyStatement = new BlockStmt();
 
-                            if (importType.returns().size() == 0) {
+                            if (importType.returns().isEmpty()) {
                                 importMethod.setType(void.class);
                                 functionBodyStatement.addStatement(importApplyHandle);
                                 functionBodyStatement.addStatement(

--- a/compiler-tests/src/test/java/run/endive/testing/InterpreterFallbackTest.java
+++ b/compiler-tests/src/test/java/run/endive/testing/InterpreterFallbackTest.java
@@ -72,7 +72,8 @@ public class InterpreterFallbackTest {
         generator.generateMetaWasm(interpretedFunctions);
     }
 
-    private String expectedMessageContent = "interpreter fallback mode: WASM function index: 2";
+    private final String expectedMessageContent =
+            "interpreter fallback mode: WASM function index: 2";
 
     @Test
     public void testDefaultInterpreterFallback() throws IOException {

--- a/compiler/src/main/java/run/endive/compiler/internal/Compiler.java
+++ b/compiler/src/main/java/run/endive/compiler/internal/Compiler.java
@@ -487,7 +487,7 @@ public final class Compiler {
     private Consumer<ClassVisitor> emitFunctionGroup(int start, int end, String internalClassName) {
         return (classWriter) -> {
             for (int i = start; i < end; i++) {
-                FunctionBody body = null;
+                FunctionBody body;
                 try {
                     int funcId = i;
                     var type = functionTypes.get(funcId);

--- a/compiler/src/main/java/run/endive/compiler/internal/Shaded.java
+++ b/compiler/src/main/java/run/endive/compiler/internal/Shaded.java
@@ -254,7 +254,7 @@ public final class Shaded {
         var prop = System.getProperty("endive.memCopyWorkaround");
 
         if (prop != null) {
-            memCopyWorkaround = Boolean.valueOf(prop);
+            memCopyWorkaround = Boolean.parseBoolean(prop);
         } else {
             memCopyWorkaround = shouldUseMemWorkaround();
         }

--- a/compiler/src/test/java/run/endive/compiler/internal/CallTest.java
+++ b/compiler/src/test/java/run/endive/compiler/internal/CallTest.java
@@ -24,7 +24,6 @@ public class CallTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void callLotsOfArgsOnDeprecatedAotMachine() throws InterruptedException {
         var module = Parser.parse(CorpusResources.getResource("compiled/lots-of-args.wat.wasm"));
         var instance =

--- a/fuzz/src/main/java/run/endive/fuzz/TestResult.java
+++ b/fuzz/src/main/java/run/endive/fuzz/TestResult.java
@@ -2,8 +2,8 @@ package run.endive.fuzz;
 
 public class TestResult {
 
-    private String oracleResult;
-    private String engineResult;
+    private final String oracleResult;
+    private final String engineResult;
 
     public TestResult(String oracleResult, String engineResult) {
         this.oracleResult = oracleResult;

--- a/fuzz/src/test/java/run/endive/fuzz/RegressionTest.java
+++ b/fuzz/src/test/java/run/endive/fuzz/RegressionTest.java
@@ -27,7 +27,7 @@ public class RegressionTest extends TestModule {
                 .flatMap(
                         dir -> {
                             var dirs = dir.listFiles();
-                            return dirs != null ? Arrays.stream(dirs) : Stream.<File>empty();
+                            return dirs != null ? Arrays.stream(dirs) : Stream.empty();
                         })
                 .filter(f -> f.isDirectory() && f.getName().startsWith("crash"))
                 .filter(f -> new File(f, "test.wasm").exists())

--- a/machine-tests/src/test/java/run/endive/testing/ThreadsProposalTest.java
+++ b/machine-tests/src/test/java/run/endive/testing/ThreadsProposalTest.java
@@ -39,8 +39,8 @@ public class ThreadsProposalTest {
         int lock(Instance instance, int mutexAddr, long expected);
     }
 
-    private static MemoryLimits memoryLimits = new MemoryLimits(1, 1, true);
-    private static List<Supplier<Memory>> memories =
+    private static final MemoryLimits memoryLimits = new MemoryLimits(1, 1, true);
+    private static final List<Supplier<Memory>> memories =
             List.of(
                     () -> new ByteArrayMemory(memoryLimits),
                     () -> new ByteBufferMemory(memoryLimits));
@@ -53,7 +53,7 @@ public class ThreadsProposalTest {
                             instBuilder.withMachineFactory(MachineFactoryCompiler::compile),
                     // build time compiler
                     (instBuilder) -> instBuilder.withMachineFactory(ThreadsExampleModule::create));
-    private static List<LockWithTimeout> locks =
+    private static final List<LockWithTimeout> locks =
             List.of(
                     ThreadsProposalTest::lockMutexWithTimeout,
                     ThreadsProposalTest::lock64MutexWithTimeout);
@@ -309,7 +309,7 @@ public class ThreadsProposalTest {
                 () -> {
                     long a;
                     do {
-                        a = (long) fencedReadAndVerify.apply()[0];
+                        a = fencedReadAndVerify.apply()[0];
                     } while (a < minIterations);
                 });
         done.set(true);

--- a/runtime-tests/src/test/java/run/endive/testing/TestModule.java
+++ b/runtime-tests/src/test/java/run/endive/testing/TestModule.java
@@ -12,7 +12,7 @@ import run.endive.wasm.WasmModule;
 
 public class TestModule {
 
-    private WasmModule module;
+    private final WasmModule module;
 
     private static final String HACK_MATCH_ALL_MALFORMED_EXCEPTION_TEXT =
             "Matching keywords to get the WebAssembly testsuite to pass: "

--- a/runtime/src/main/java/run/endive/runtime/ImportValue.java
+++ b/runtime/src/main/java/run/endive/runtime/ImportValue.java
@@ -5,7 +5,7 @@ package run.endive.runtime;
  * It is an address denoting either a function instance, table instance, memory instance,
  * or global instances in the shared store.
  *
- * See also <a href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval">External Values</a>.
+ * <p>See also <a href="https://webassembly.github.io/spec/core/exec/runtime.html#syntax-externval">External Values</a>.
  *
  * @see ExportFunction
  */

--- a/runtime/src/main/java/run/endive/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/run/endive/runtime/InterpreterMachine.java
@@ -3922,8 +3922,7 @@ public class InterpreterMachine implements Machine {
         var tagType = exception.instance().type(tag.tagType().typeIdx());
         var params = tagType.params();
         int slot = 0;
-        for (int i = 0; i < params.size(); i++) {
-            var p = params.get(i);
+        for (ValType p : params) {
             if (p.isObjectRef()) {
                 // This position is a ref (even if the value is null)
                 stack.pushRef(refArgs != null && slot < refArgs.length ? refArgs[slot] : null);

--- a/runtime/src/main/java/run/endive/runtime/StackFrame.java
+++ b/runtime/src/main/java/run/endive/runtime/StackFrame.java
@@ -73,8 +73,7 @@ public class StackFrame {
 
         // initialize codesegment locals.
         int j = 0;
-        for (var i = 0; i < localTypes.size(); i++) {
-            ValType type = localTypes.get(i);
+        for (ValType type : localTypes) {
             var idx = j + sizeOf(argsTypes);
             if (!type.equals(ValType.V128)) {
                 if (type.isReference()) {

--- a/runtime/src/main/java/run/endive/runtime/Store.java
+++ b/runtime/src/main/java/run/endive/runtime/Store.java
@@ -98,9 +98,8 @@ public class Store {
      * All the exported functions, globals, memories, and tables are added to the store
      * with the given name.
      *
-     * For instance, if a module named "myModule" exports a function
+     * <p>For instance, if a module named "myModule" exports a function
      * named "myFunction", the function will be added to the store with the name "myFunction.myModule".
-     *
      */
     public Store register(String name, Instance instance) {
         ExportSection exportSection = instance.module().exportSection();

--- a/runtime/src/test/java/run/endive/runtime/MemoryStressTest.java
+++ b/runtime/src/test/java/run/endive/runtime/MemoryStressTest.java
@@ -89,7 +89,7 @@ public class MemoryStressTest {
         final RwLock lock = new RwLock(memorySupplier.get(), 0);
         final long deadline = System.currentTimeMillis() + 3_000;
 
-        final List<Thread> threads = new ArrayList<Thread>();
+        final List<Thread> threads = new ArrayList<>();
         for (int r = 0; r < 6; r++) {
             threads.add(
                     new Thread(

--- a/runtime/src/test/java/run/endive/runtime/WasmModuleTest.java
+++ b/runtime/src/test/java/run/endive/runtime/WasmModuleTest.java
@@ -227,7 +227,7 @@ public class WasmModuleTest {
                             return new ByteBufferMemory(limits);
                         })
                 .build();
-        assertEquals(true, memoryCreated.get());
+        assertTrue(memoryCreated.get());
     }
 
     @Test
@@ -396,17 +396,17 @@ public class WasmModuleTest {
         assertEquals(factorial(number), result[0]);
 
         // IIUC: 3 values returning from last CALL + 1 result
-        assertTrue(finalStackSize.get() == 4L);
+        assertEquals(4L, finalStackSize.get());
     }
 
     @Test
     public void shouldEasilyObtainExportedEntities() {
         var instance = Instance.builder(loadModule("compiled/exports.wat.wasm")).build();
 
-        assertNotNull(instance.exports().memory("mem").pages());
-        assertNotNull(instance.exports().table("tab").size());
-        assertNotNull(instance.exports().tag("tag").tagType());
-        assertNotNull(instance.exports().global("glob1").getValue());
+        instance.exports().memory("mem").pages();
+        instance.exports().table("tab").size();
+        instance.exports().tag("tag").tagType();
+        instance.exports().global("glob1").getValue();
         assertNotNull(instance.exports().function("get-1").apply());
     }
 
@@ -576,6 +576,7 @@ public class WasmModuleTest {
         ExecutorService service = Executors.newSingleThreadExecutor();
         var future = service.submit(() -> function.apply());
         assertThrows(TimeoutException.class, () -> future.get(100, TimeUnit.MILLISECONDS));
+        service.shutdown();
     }
 
     // Testing tail call edge cases
@@ -858,10 +859,7 @@ public class WasmModuleTest {
                         });
         var instance =
                 Instance.builder(loadModule("compiled/host-function.wat.wasm"))
-                        .withImportValues(
-                                ImportValues.builder()
-                                        .addFunction(new HostFunction[] {func})
-                                        .build())
+                        .withImportValues(ImportValues.builder().addFunction(func).build())
                         .build();
         var logIt = instance.export("logIt");
         var e = assertThrows(WasmEngineException.class, logIt::apply);

--- a/simd/src/main/java/run/endive/simd/SimdInterpreterMachine.java
+++ b/simd/src/main/java/run/endive/simd/SimdInterpreterMachine.java
@@ -1376,13 +1376,9 @@ public final class SimdInterpreterMachine extends InterpreterMachine {
         }
     }
 
-    private static long addSatU(short a, Short b) {
+    private static long addSatU(short a, short b) {
         int result = Short.toUnsignedInt(a) + Short.toUnsignedInt(b);
-        if (result >= 0xFFFF) {
-            return 0xFFFF;
-        } else {
-            return result;
-        }
+        return Math.min(result, 0xFFFF);
     }
 
     private static byte subSatS(byte a, byte b) {
@@ -3000,7 +2996,7 @@ public final class SimdInterpreterMachine extends InterpreterMachine {
         long resultHigh = 0L;
 
         for (int i = 0; i < 16; i++) {
-            long id = 0;
+            long id;
             if (i < 8) {
                 id = (idxLow >> (i * 8)) & 0xFFL;
             } else {

--- a/test-gen-lib/src/main/java/run/endive/testgen/JavaTestGen.java
+++ b/test-gen-lib/src/main/java/run/endive/testgen/JavaTestGen.java
@@ -143,7 +143,7 @@ public class JavaTestGen {
                 "store",
                 new NameExpr("new Store().addImportValues(Spectest.toImportValues())"));
 
-        String currentWasmFile = null;
+        String currentWasmFile;
         for (var cmd : wast.commands()) {
             switch (cmd.type()) {
                 case MODULE:
@@ -428,7 +428,7 @@ public class JavaTestGen {
                                         .collect(Collectors.toList())
                                 : List.<String>of();
                 var adaptedArgs =
-                        (args == null || args.size() == 0)
+                        args.isEmpty()
                                 ? ""
                                 : args.stream().collect(Collectors.joining(").add(", ".add(", ")"));
                 invocationMethod = ".apply(ArgsAdapter.builder()" + adaptedArgs + ".build()" + ")";
@@ -601,11 +601,11 @@ public class JavaTestGen {
 
         String wasmFile = getWasmFile(cmd, wasmClasspath);
 
-        var assignementStmt = (cmd.text() != null) ? "var exception = " : "";
+        var assignmentStmt = (cmd.text() != null) ? "var exception = " : "";
 
         var assertThrows =
                 new NameExpr(
-                        assignementStmt
+                        assignmentStmt
                                 + "assertThrows("
                                 + exceptionType
                                 + ".class, () -> "

--- a/test-gen-lib/src/main/java/run/endive/testgen/wast/WasmValue.java
+++ b/test-gen-lib/src/main/java/run/endive/testgen/wast/WasmValue.java
@@ -134,7 +134,7 @@ public class WasmValue {
         if (value == null) {
             // according to
             // https://github.com/WebAssembly/spec/blob/05949f507908aac3ad2a21661b5c39fa013da950/interpreter/script/js.ml#L150
-            // ref.func should check that its a function, and ref.extern should check the returned
+            // ref.func should check that it's a function, and ref.extern should check the returned
             // reference is not null
             switch (type) {
                 case FUNC_REF:
@@ -285,14 +285,14 @@ public class WasmValue {
 
     public String intLaneValue(String v) {
         var longValue = Long.parseLong(v);
-        return Integer.toUnsignedString((int) (0xFFFFFFFF & longValue)) + "L";
+        return Integer.toUnsignedString((int) longValue) + "L";
     }
 
     /**
      * Generate assertion for CallResult from applyWithRefs.
      *
-     * Object ref types use cr.refResult(i) and compare with Java null/not-null.
-     * Numeric types use cr.longResult(i) and compare with expected values.
+     * <p>Object ref types use {@code cr.refResult(i)} and compare with Java null/not-null.
+     * Numeric types use {@code cr.longResult(i)} and compare with expected values.
      */
     public NameExpr toRefAssertion(String resultVar, String moduleName) {
         if (value == null) {
@@ -392,7 +392,7 @@ public class WasmValue {
             case EQ_REF:
             case I31_REF:
             case FUNC_REF:
-                if (value[0].toString().equals("null")) {
+                if (value[0].equals("null")) {
                     return "Value.REF_NULL_VALUE";
                 }
                 return value[0];

--- a/test-gen-plugin/README.md
+++ b/test-gen-plugin/README.md
@@ -1,5 +1,6 @@
 # test-gen-plugin
 
-<internal-usage-only>
+> [!WARNING]
+> internal-usage-only
 
-A maven plugin that handles the test generation that exercises both the wasm package and the runtime package. Tests are parsed from the [Wasm testsuite](https://github.com/WebAssembly/testsuite) and generate Java JUnit tests.
+A Maven plugin that handles the test generation that exercises both the wasm package and the runtime package. Tests are parsed from the [Wasm testsuite](https://github.com/WebAssembly/testsuite) and generate Java JUnit tests.

--- a/wasi/src/main/java/module-info.java
+++ b/wasi/src/main/java/module-info.java
@@ -2,6 +2,8 @@ module run.endive.wasi {
     requires static run.endive.annotations;
     requires run.endive.log;
     requires transitive run.endive.runtime;
+
+    // Needed for `javax.annotation.processing.Generated` annotation in generated ModuleFactory
     requires static java.compiler;
 
     exports run.endive.wasi;

--- a/wasi/src/test/java/wasi/WasiPreview1Test.java
+++ b/wasi/src/test/java/wasi/WasiPreview1Test.java
@@ -42,7 +42,7 @@ public class WasiPreview1Test {
         Instance.builder(loadModule("compiled/hello-wasi.wat.wasm"))
                 .withImportValues(imports)
                 .build();
-        assertEquals(fakeStdout.output().strip(), "hello world");
+        assertEquals("hello world", fakeStdout.output().strip());
     }
 
     @Test
@@ -72,7 +72,7 @@ public class WasiPreview1Test {
         Instance.builder(loadModule("compiled/greet-wasi.rs.wasm"))
                 .withImportValues(imports)
                 .build();
-        assertEquals(fakeStdout.output().strip(), "Hello, Benjamin!");
+        assertEquals("Hello, Benjamin!", fakeStdout.output().strip());
     }
 
     @Test
@@ -88,7 +88,7 @@ public class WasiPreview1Test {
                 .withImportValues(imports)
                 .build();
 
-        assertEquals(fakeStdout.output(), "{\"foo\":3,\"newBar\":\"baz!\"}");
+        assertEquals("{\"foo\":3,\"newBar\":\"baz!\"}", fakeStdout.output());
     }
 
     @Test

--- a/wasm-tools/src/main/java/run/endive/tools/wasm/Validate.java
+++ b/wasm-tools/src/main/java/run/endive/tools/wasm/Validate.java
@@ -148,7 +148,7 @@ public final class Validate {
         }
 
         public Validate build() {
-            return new Validate(Collections.unmodifiableList(new ArrayList<>(features)));
+            return new Validate(List.copyOf(features));
         }
     }
 }

--- a/wasm-tools/src/main/java/run/endive/tools/wasm/Wast2Json.java
+++ b/wasm-tools/src/main/java/run/endive/tools/wasm/Wast2Json.java
@@ -13,7 +13,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import run.endive.log.Logger;
 import run.endive.log.SystemLogger;
 import run.endive.runtime.ByteArrayMemory;
@@ -79,7 +78,7 @@ public final class Wast2Json {
             args.add("--output");
             args.add(outputFolder.resolve(output.getName()).resolve("spec.json").toString());
             args.addAll(List.of(options));
-            logger.info("Running command: " + args.stream().collect(Collectors.joining(" ")));
+            logger.info("Running command: " + String.join(" ", args));
             wasiOpts.withArguments(args);
 
             try (var wasi =

--- a/wasm/src/main/java/run/endive/wasm/Parser.java
+++ b/wasm/src/main/java/run/endive/wasm/Parser.java
@@ -454,7 +454,7 @@ public final class Parser {
 
     // https://webassembly.github.io/spec/core/binary/modules.html#binary-module
     private static class SectionsValidator {
-        private List<Integer> sectionsOrder = new ArrayList<>();
+        private final List<Integer> sectionsOrder = new ArrayList<>();
         private int maxSection = -1;
 
         SectionsValidator() {
@@ -651,9 +651,11 @@ public final class Parser {
                         r.resolve(typeSection);
                     }
                 }
-                if (ct.arrayType() != null
-                        && ct.arrayType().fieldType().storageType().valType() != null) {
-                    ct.arrayType().fieldType().storageType().valType().resolve(typeSection);
+                if (ct.arrayType() != null) {
+                    var valType = ct.arrayType().fieldType().storageType().valType();
+                    if (valType != null) {
+                        valType.resolve(typeSection);
+                    }
                 }
                 if (ct.structType() != null) {
                     for (var t : ct.structType().fieldTypes()) {
@@ -697,7 +699,7 @@ public final class Parser {
 
                         var limitType = readByte(buffer);
                         var min = (int) readVarUInt32(buffer);
-                        TableLimits limits = null;
+                        TableLimits limits;
                         switch (limitType) {
                             case 0x00:
                                 limits = new TableLimits(min);
@@ -1277,11 +1279,6 @@ public final class Parser {
             throw new MalformedException("illegal opcode, op value " + String.format("%02X ", b));
         }
         var signature = OpCode.signature(op);
-
-        switch (op) {
-            default:
-                break;
-        }
 
         // reserving an operand in those two operations to inject
         // a ValType hint at validation time

--- a/wasm/src/main/java/run/endive/wasm/Validator.java
+++ b/wasm/src/main/java/run/endive/wasm/Validator.java
@@ -319,7 +319,7 @@ final class Validator {
     private void validateMemAlign(long current, long expected) {
         if (current != expected) {
             throw new InvalidException(
-                    "invalid memory alignement, current: " + current + ", expected: " + expected);
+                    "invalid memory alignment, current: " + current + ", expected: " + expected);
         }
     }
 
@@ -667,7 +667,7 @@ final class Validator {
     void validateTags() {
         for (var tagType : module.tagSection().map(ts -> ts.types()).orElse(new TagType[0])) {
             var type = module.typeSection().getType(tagType.typeIdx());
-            if (type.returns().size() > 0) {
+            if (!type.returns().isEmpty()) {
                 throw new InvalidException("non-empty tag result type index: " + tagType.typeIdx());
             }
         }
@@ -882,7 +882,7 @@ final class Validator {
             }
         }
 
-        if (valTypeStack.size() < 1) {
+        if (valTypeStack.isEmpty()) {
             throw new InvalidException("type mismatch, no constant expressions found");
         }
         if (valTypeStack.size() != 1) {
@@ -905,7 +905,7 @@ final class Validator {
         }
     }
 
-    private static int[] typesWithDefaultValue =
+    private static final int[] typesWithDefaultValue =
             new int[] {
                 ValType.ID.F64,
                 ValType.ID.F32,
@@ -977,8 +977,7 @@ final class Validator {
                         // and now the catches
                         var catches = CatchOpCode.decode(op.operands());
 
-                        for (int idx = 0; idx < catches.size(); idx++) {
-                            var currentCatch = catches.get(idx);
+                        for (CatchOpCode.Catch currentCatch : catches) {
                             if (ctrlFrameStack.size() < currentCatch.label()) {
                                 throw new InvalidException("something something");
                             }
@@ -1909,7 +1908,7 @@ final class Validator {
                         if (global.mutabilityType() == MutabilityType.Const) {
                             // global.wast in the origin spec and function references
                             // have exact same test that exact two different errors
-                            // TOOD: figure out which one
+                            // TODO: figure out which one
                             throw new InvalidException("global is immutable, immutable global");
                         }
                         popVal(global.valueType());

--- a/wasm/src/main/java/run/endive/wasm/WasmModule.java
+++ b/wasm/src/main/java/run/endive/wasm/WasmModule.java
@@ -304,7 +304,7 @@ public final class WasmModule {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof WasmModule)) {
+        if (!(o instanceof WasmModule)) {
             return false;
         }
         WasmModule that = (WasmModule) o;

--- a/wasm/src/main/java/run/endive/wasm/types/ActiveDataSegment.java
+++ b/wasm/src/main/java/run/endive/wasm/types/ActiveDataSegment.java
@@ -26,7 +26,7 @@ public final class ActiveDataSegment extends DataSegment {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof ActiveDataSegment)) {
+        if (!(o instanceof ActiveDataSegment)) {
             return false;
         }
         if (!super.equals(o)) {

--- a/wasm/src/main/java/run/endive/wasm/types/AnnotatedInstruction.java
+++ b/wasm/src/main/java/run/endive/wasm/types/AnnotatedInstruction.java
@@ -221,7 +221,7 @@ public final class AnnotatedInstruction extends Instruction {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof AnnotatedInstruction)) {
+        if (!(o instanceof AnnotatedInstruction)) {
             return false;
         }
         AnnotatedInstruction that = (AnnotatedInstruction) o;

--- a/wasm/src/main/java/run/endive/wasm/types/CodeSection.java
+++ b/wasm/src/main/java/run/endive/wasm/types/CodeSection.java
@@ -67,7 +67,7 @@ public final class CodeSection extends Section {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof CodeSection)) {
+        if (!(o instanceof CodeSection)) {
             return false;
         }
         CodeSection that = (CodeSection) o;

--- a/wasm/src/main/java/run/endive/wasm/types/DataCountSection.java
+++ b/wasm/src/main/java/run/endive/wasm/types/DataCountSection.java
@@ -34,7 +34,7 @@ public final class DataCountSection extends Section {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof DataCountSection)) {
+        if (!(o instanceof DataCountSection)) {
             return false;
         }
         DataCountSection that = (DataCountSection) o;

--- a/wasm/src/main/java/run/endive/wasm/types/DataSection.java
+++ b/wasm/src/main/java/run/endive/wasm/types/DataSection.java
@@ -55,7 +55,7 @@ public final class DataSection extends Section {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof DataSection)) {
+        if (!(o instanceof DataSection)) {
             return false;
         }
         DataSection that = (DataSection) o;

--- a/wasm/src/main/java/run/endive/wasm/types/DataSegment.java
+++ b/wasm/src/main/java/run/endive/wasm/types/DataSegment.java
@@ -19,7 +19,7 @@ public abstract class DataSegment {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof DataSegment)) {
+        if (!(o instanceof DataSegment)) {
             return false;
         }
         DataSegment that = (DataSegment) o;

--- a/wasm/src/main/java/run/endive/wasm/types/Element.java
+++ b/wasm/src/main/java/run/endive/wasm/types/Element.java
@@ -51,7 +51,7 @@ public abstract class Element {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof Element)) {
+        if (!(o instanceof Element)) {
             return false;
         }
         Element element = (Element) o;

--- a/wasm/src/main/java/run/endive/wasm/types/ElementSection.java
+++ b/wasm/src/main/java/run/endive/wasm/types/ElementSection.java
@@ -58,7 +58,7 @@ public final class ElementSection extends Section {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof ElementSection)) {
+        if (!(o instanceof ElementSection)) {
             return false;
         }
         ElementSection that = (ElementSection) o;

--- a/wasm/src/main/java/run/endive/wasm/types/ExportSection.java
+++ b/wasm/src/main/java/run/endive/wasm/types/ExportSection.java
@@ -51,7 +51,7 @@ public final class ExportSection extends Section {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof ExportSection)) {
+        if (!(o instanceof ExportSection)) {
             return false;
         }
         ExportSection that = (ExportSection) o;

--- a/wasm/src/main/java/run/endive/wasm/types/FunctionBody.java
+++ b/wasm/src/main/java/run/endive/wasm/types/FunctionBody.java
@@ -25,7 +25,7 @@ public final class FunctionBody {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof FunctionBody)) {
+        if (!(o instanceof FunctionBody)) {
             return false;
         }
         FunctionBody that = (FunctionBody) o;

--- a/wasm/src/main/java/run/endive/wasm/types/FunctionSection.java
+++ b/wasm/src/main/java/run/endive/wasm/types/FunctionSection.java
@@ -54,7 +54,7 @@ public final class FunctionSection extends Section {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof FunctionSection)) {
+        if (!(o instanceof FunctionSection)) {
             return false;
         }
         FunctionSection that = (FunctionSection) o;

--- a/wasm/src/main/java/run/endive/wasm/types/Global.java
+++ b/wasm/src/main/java/run/endive/wasm/types/Global.java
@@ -44,7 +44,7 @@ public final class Global {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof Global)) {
+        if (!(o instanceof Global)) {
             return false;
         }
         Global global = (Global) o;

--- a/wasm/src/main/java/run/endive/wasm/types/GlobalSection.java
+++ b/wasm/src/main/java/run/endive/wasm/types/GlobalSection.java
@@ -55,7 +55,7 @@ public final class GlobalSection extends Section {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof GlobalSection)) {
+        if (!(o instanceof GlobalSection)) {
             return false;
         }
         GlobalSection that = (GlobalSection) o;

--- a/wasm/src/main/java/run/endive/wasm/types/ImportSection.java
+++ b/wasm/src/main/java/run/endive/wasm/types/ImportSection.java
@@ -60,7 +60,7 @@ public final class ImportSection extends Section {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof ImportSection)) {
+        if (!(o instanceof ImportSection)) {
             return false;
         }
         ImportSection that = (ImportSection) o;

--- a/wasm/src/main/java/run/endive/wasm/types/Instruction.java
+++ b/wasm/src/main/java/run/endive/wasm/types/Instruction.java
@@ -56,7 +56,7 @@ public class Instruction {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof Instruction)) {
+        if (!(o instanceof Instruction)) {
             return false;
         }
         Instruction that = (Instruction) o;

--- a/wasm/src/main/java/run/endive/wasm/types/Memory.java
+++ b/wasm/src/main/java/run/endive/wasm/types/Memory.java
@@ -32,7 +32,7 @@ public final class Memory {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof Memory)) {
+        if (!(o instanceof Memory)) {
             return false;
         }
         Memory memory = (Memory) o;

--- a/wasm/src/main/java/run/endive/wasm/types/MemorySection.java
+++ b/wasm/src/main/java/run/endive/wasm/types/MemorySection.java
@@ -51,7 +51,7 @@ public final class MemorySection extends Section {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof MemorySection)) {
+        if (!(o instanceof MemorySection)) {
             return false;
         }
         MemorySection that = (MemorySection) o;

--- a/wasm/src/main/java/run/endive/wasm/types/StartSection.java
+++ b/wasm/src/main/java/run/endive/wasm/types/StartSection.java
@@ -36,7 +36,7 @@ public final class StartSection extends Section {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof StartSection)) {
+        if (!(o instanceof StartSection)) {
             return false;
         }
         StartSection that = (StartSection) o;

--- a/wasm/src/main/java/run/endive/wasm/types/StructType.java
+++ b/wasm/src/main/java/run/endive/wasm/types/StructType.java
@@ -35,7 +35,7 @@ public final class StructType {
     }
 
     public static final class Builder {
-        private List<FieldType> fieldTypes = new ArrayList<>();
+        private final List<FieldType> fieldTypes = new ArrayList<>();
 
         private Builder() {}
 

--- a/wasm/src/main/java/run/endive/wasm/types/Table.java
+++ b/wasm/src/main/java/run/endive/wasm/types/Table.java
@@ -56,7 +56,7 @@ public class Table {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof Table)) {
+        if (!(o instanceof Table)) {
             return false;
         }
         Table table = (Table) o;

--- a/wasm/src/main/java/run/endive/wasm/types/TableSection.java
+++ b/wasm/src/main/java/run/endive/wasm/types/TableSection.java
@@ -51,7 +51,7 @@ public final class TableSection extends Section {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof TableSection)) {
+        if (!(o instanceof TableSection)) {
             return false;
         }
         TableSection that = (TableSection) o;

--- a/wasm/src/main/java/run/endive/wasm/types/TypeSection.java
+++ b/wasm/src/main/java/run/endive/wasm/types/TypeSection.java
@@ -375,7 +375,7 @@ public final class TypeSection extends Section {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof TypeSection)) {
+        if (!(o instanceof TypeSection)) {
             return false;
         }
         TypeSection that = (TypeSection) o;

--- a/wasm/src/main/java/run/endive/wasm/types/ValType.java
+++ b/wasm/src/main/java/run/endive/wasm/types/ValType.java
@@ -13,28 +13,29 @@ public final class ValType {
     private static final long OPCODE_MASK = 0xFFFFFFFFL;
     private static final long TYPEIDX_SHIFT = 32;
 
-    public static ValType BOT = new ValType(ID.BOT);
-    public static ValType F64 = new ValType(ID.F64);
+    public static final ValType BOT = new ValType(ID.BOT);
+    public static final ValType F64 = new ValType(ID.F64);
 
-    public static ValType F32 = new ValType(ID.F32);
-    public static ValType I64 = new ValType(ID.I64);
+    public static final ValType F32 = new ValType(ID.F32);
+    public static final ValType I64 = new ValType(ID.I64);
 
-    public static ValType I32 = new ValType(ID.I32);
+    public static final ValType I32 = new ValType(ID.I32);
 
-    public static ValType V128 = new ValType(ID.V128);
-    public static ValType FuncRef = new ValType(ID.FuncRef);
-    public static ValType ExnRef = new ValType(ID.ExnRef);
-    public static ValType ExternRef = new ValType(ID.ExternRef);
-    public static ValType AnyRef = new ValType(ID.AnyRef);
-    public static ValType EqRef = new ValType(ID.EqRef);
-    public static ValType I31Ref = new ValType(ID.i31);
-    public static ValType StructRef = new ValType(ID.StructRef);
-    public static ValType ArrayRef = new ValType(ID.ArrayRef);
-    public static ValType NoneRef = new ValType(ID.NoneRef);
-    public static ValType NoFuncRef = new ValType(ID.NoFuncRef);
-    public static ValType NoExternRef = new ValType(ID.NoExternRef);
+    public static final ValType V128 = new ValType(ID.V128);
+    public static final ValType FuncRef = new ValType(ID.FuncRef);
+    public static final ValType ExnRef = new ValType(ID.ExnRef);
+    public static final ValType ExternRef = new ValType(ID.ExternRef);
+    public static final ValType AnyRef = new ValType(ID.AnyRef);
+    public static final ValType EqRef = new ValType(ID.EqRef);
+    public static final ValType I31Ref = new ValType(ID.i31);
+    public static final ValType StructRef = new ValType(ID.StructRef);
+    public static final ValType ArrayRef = new ValType(ID.ArrayRef);
+    public static final ValType NoneRef = new ValType(ID.NoneRef);
+    public static final ValType NoFuncRef = new ValType(ID.NoFuncRef);
+    public static final ValType NoExternRef = new ValType(ID.NoExternRef);
 
-    public static ValType RefBot = new ValType(ValType.ID.Ref, ValType.TypeIdxCode.BOT.code());
+    public static final ValType RefBot =
+            new ValType(ValType.ID.Ref, ValType.TypeIdxCode.BOT.code());
 
     private final long id;
 

--- a/wasm/src/test/java/run/endive/wasm/WasmModuleTest.java
+++ b/wasm/src/test/java/run/endive/wasm/WasmModuleTest.java
@@ -21,6 +21,7 @@ public class WasmModuleTest {
         var mod1 = Parser.parse(CorpusResources.getResource("compiled/count_vowels.rs.wasm"));
         var mod2 = Parser.parse(CorpusResources.getResource("compiled/count_vowels.rs.wasm"));
 
+        //noinspection SimplifiableAssertion; intentionally test `equals` implementation
         assertTrue(mod1.equals(mod2));
     }
 }

--- a/wasm/src/test/java/run/endive/wasm/types/ValueTest.java
+++ b/wasm/src/test/java/run/endive/wasm/types/ValueTest.java
@@ -1,6 +1,7 @@
 package run.endive.wasm.types;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -39,6 +40,8 @@ public class ValueTest {
         assertTrue(true);
     }
 
+    // Suppress IntelliJ warnings for explicit `equals` calls
+    @SuppressWarnings({"SimplifiableAssertion", "EqualsWithItself", "ConstantValue"})
     @Test
     public void equalsContract() {
 
@@ -47,12 +50,13 @@ public class ValueTest {
         var i32TwentyOne = Value.i32(21);
         var f32TwentyOne = Value.f32(Float.floatToIntBits(21.0f));
 
-        assertEquals(i32FortyTwo, i32FortyTwo);
-        assertEquals(i32FortyTwo, Value.i32(42));
-        assertNotEquals(i32FortyTwo, i32TwentyOne);
-        assertNotEquals(i32FortyTwo, null);
-        assertNotEquals(i32TwentyOne, f32TwentyOne);
-        assertNotEquals(i32FortyTwo, i64FortyTwo);
+        // Explicitly call `equals` here to avoid any shortcuts by JUnit `assertEquals`
+        assertTrue(i32FortyTwo.equals(i32FortyTwo));
+        assertTrue(i32FortyTwo.equals(Value.i32(42)));
+        assertFalse(i32FortyTwo.equals(i32TwentyOne));
+        assertFalse(i32FortyTwo.equals(null));
+        assertFalse(i32TwentyOne.equals(f32TwentyOne));
+        assertFalse(i32FortyTwo.equals(i64FortyTwo));
     }
 
     @Test


### PR DESCRIPTION
- Fix typos
- Fix redundant `== null` check before `! instanceof`
- Remove redundant local var initializers when var is always assigned before access (Java compiler ensures this)
- Make fields `final`
- For collections use `isEmpty()` instead of `size()` (potentially more efficient)
- Use enhanced for-each loop instead of indexed loop