### PR TITLE
Fix meta functions count to only count function imports

### DIFF
--- a/build-time-compiler/src/main/java/run/endive/build/time/compiler/Generator.java
+++ b/build-time-compiler/src/main/java/run/endive/build/time/compiler/Generator.java
@@ -43,6 +43,7 @@ import run.endive.runtime.Machine;
 import run.endive.wasm.Parser;
 import run.endive.wasm.WasmModule;
 import run.endive.wasm.WasmWriter;
+import run.endive.wasm.types.ExternalType;
 import run.endive.wasm.types.OpCode;
 import run.endive.wasm.types.RawSection;
 import run.endive.wasm.types.SectionId;
@@ -150,7 +151,7 @@ public class Generator {
                         var source = ByteBuffer.wrap(((RawSection) section).contents());
 
                         var out = new ByteArrayOutputStream();
-                        var importFuncs = module.importSection().importCount();
+                        var importFuncs = module.importSection().count(ExternalType.FUNCTION);
                         int count = module.codeSection().functionBodyCount();
                         writeVarUInt32(out, count);
                         var actual = readVarUInt32(source);

--- a/compiler-tests/src/test/java/run/endive/testing/InterpreterFallbackTest.java
+++ b/compiler-tests/src/test/java/run/endive/testing/InterpreterFallbackTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static run.endive.corpus.WatGenerator.methodTooLarge;
+import static run.endive.corpus.WatGenerator.methodTooLargeWithMemoryImport;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -28,7 +29,9 @@ import org.junit.jupiter.api.Test;
 import run.endive.build.time.compiler.Config;
 import run.endive.build.time.compiler.Generator;
 import run.endive.compiler.InterpreterFallback;
+import run.endive.runtime.ByteBufferMemory;
 import run.endive.runtime.HostFunction;
+import run.endive.runtime.ImportMemory;
 import run.endive.runtime.ImportValues;
 import run.endive.runtime.Instance;
 import run.endive.runtime.Machine;
@@ -37,6 +40,7 @@ import run.endive.wasm.Parser;
 import run.endive.wasm.WasmEngineException;
 import run.endive.wasm.WasmModule;
 import run.endive.wasm.types.FunctionType;
+import run.endive.wasm.types.MemoryLimits;
 import run.endive.wasm.types.ValType;
 
 public class InterpreterFallbackTest {
@@ -215,6 +219,60 @@ public class InterpreterFallbackTest {
 
         var output = captureOutput(() -> generateAll(generator));
         assertEquals("", output);
+    }
+
+    @Test
+    public void testInterpreterFallbackWithMemoryImport() throws Exception {
+        Path srcDir = Path.of("target", "test-fixtures-mem", "src");
+        Files.createDirectories(srcDir);
+        Path memClassDir = Path.of("target", "test-fixtures-mem", "classes");
+        Files.createDirectories(memClassDir);
+
+        String wat = methodTooLargeWithMemoryImport(20_000);
+        var wasm = Wat2Wasm.parse(wat);
+        var memWasmFile = srcDir.resolve("main.wasm");
+        Files.write(memWasmFile, wasm);
+
+        var config =
+                Config.builder()
+                        .withWasmFile(memWasmFile)
+                        .withTargetSourceFolder(memClassDir)
+                        .withTargetClassFolder(memClassDir)
+                        .withTargetWasmFolder(memClassDir)
+                        .withName("run.endive.testing.TestMem")
+                        .withInterpreterFallback(InterpreterFallback.SILENT)
+                        .build();
+        var generator = new Generator(config);
+        generator.generateSources();
+        var interpretedFunctions = generator.generateResources();
+        generator.generateMetaWasm(interpretedFunctions);
+
+        var url = memClassDir.toUri().toURL();
+        var cl = new URLClassLoader(new URL[] {url});
+        var machineClass = cl.loadClass("run.endive.testing.TestMemMachine");
+        Function<Instance, Machine> machineFactory = createMachineFactory(machineClass);
+
+        var hostStackTrace = new ArrayList<String>();
+        var hostFunc = createHostFunc(hostStackTrace);
+
+        WasmModule module;
+        try (InputStream in = machineClass.getResourceAsStream("TestMem.meta")) {
+            module = Parser.parse(in);
+        }
+
+        var memory = new ByteBufferMemory(new MemoryLimits(1));
+        var instance =
+                Instance.builder(module)
+                        .withImportValues(
+                                ImportValues.builder()
+                                        .addFunction(hostFunc)
+                                        .addMemory(new ImportMemory("env", "memory", memory))
+                                        .build())
+                        .withMachineFactory(machineFactory)
+                        .withStart(false)
+                        .build();
+
+        assertEquals(35, instance.export("func_2").apply(0)[0]);
     }
 
     private static HostFunction createHostFunc(List<String> hostStackTrace) {

--- a/wasm-corpus/src/main/java/run/endive/corpus/WatGenerator.java
+++ b/wasm-corpus/src/main/java/run/endive/corpus/WatGenerator.java
@@ -34,6 +34,17 @@ public final class WatGenerator {
                         "instructions", instructions));
     }
 
+    public static String methodTooLargeWithMemoryImport(int funcSize) {
+        ArrayList<Integer> instructions = new ArrayList<>();
+        for (int i = 0; i < funcSize; i++) {
+            instructions.add(i + 1);
+        }
+
+        return render(
+                "/run/endive/corpus/method_too_large_with_memory_import.wat",
+                Map.of("instructions", instructions));
+    }
+
     public static String methodTooLarge(int funcSize) {
         ArrayList<Integer> instructions = new ArrayList<>();
         for (int i = 0; i < funcSize; i++) {

--- a/wasm-corpus/src/main/resources/run/endive/corpus/method_too_large_with_memory_import.wat
+++ b/wasm-corpus/src/main/resources/run/endive/corpus/method_too_large_with_memory_import.wat
@@ -1,0 +1,39 @@
+(module
+  (type (;0;) (func (param i32) (result i32)))
+  (import "funcs" "host_func" (func $host_func (type 0)))
+  (import "env" "memory" (memory 1))
+
+  (table 1 funcref)
+  (elem (i32.const 0) $func_0)
+
+  (func $func_0 (export "func_0") (param i32) (result i32)
+    local.get 0
+    call $host_func
+  )
+  (func $func_1 (export "func_1") (param i32) (result i32)
+    local.get 0
+
+    #foreach ($instr in $instructions)
+    i32.const 1
+    i32.add
+    i32.const 1
+    i32.sub
+    #end
+
+    i32.const 0
+    i32.eq
+    if (result i32)
+      local.get 0
+      call $func_0
+    else
+      local.get 0
+      i32.const 0
+      call_indirect (type 0)
+    end
+  )
+
+  (func $func_2 (export "func_2") (param i32) (result i32)
+    local.get 0
+    call $func_1
+  )
+)


### PR DESCRIPTION
importSection().importCount() counted all imports (functions, memories, tables, globals), causing wrong function index offsets when non-function imports are present.

Originally reported here: https://github.com/roastedroot/protobuf4j/issues/97