### PR TITLE
Decode block types as s33 and keep type indices distinct from value types

### DIFF
--- a/compiler/src/main/java/run/endive/compiler/internal/WasmAnalyzer.java
+++ b/compiler/src/main/java/run/endive/compiler/internal/WasmAnalyzer.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 import run.endive.wasm.WasmEngineException;
 import run.endive.wasm.WasmModule;
 import run.endive.wasm.types.AnnotatedInstruction;
+import run.endive.wasm.types.BlockType;
 import run.endive.wasm.types.CatchOpCode;
 import run.endive.wasm.types.ExternalType;
 import run.endive.wasm.types.FieldType;
@@ -1807,15 +1808,18 @@ final class WasmAnalyzer {
     }
 
     private FunctionType blockType(Instruction ins) {
-        var typeId = ins.operand(0);
-        if (typeId == 0x40) {
+        var blockType = ins.operand(0);
+        if (BlockType.isEmpty(blockType)) {
             return FunctionType.empty();
         }
-        if (ValType.isValid(typeId)) {
+        if (BlockType.isValueType(blockType)) {
             return FunctionType.returning(
-                    ValType.builder().fromId(typeId).build().resolve(module.typeSection()));
+                    ValType.builder()
+                            .fromId(BlockType.valueTypeId(blockType))
+                            .build()
+                            .resolve(module.typeSection()));
         }
-        return module.typeSection().getType((int) typeId);
+        return module.typeSection().getType((int) BlockType.typeIndex(blockType));
     }
 
     private static List<ValType> getGlobalTypes(WasmModule module) {

--- a/compiler/src/test/java/run/endive/compiler/internal/BlockTypeTest.java
+++ b/compiler/src/test/java/run/endive/compiler/internal/BlockTypeTest.java
@@ -1,0 +1,28 @@
+package run.endive.compiler.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import run.endive.compiler.MachineFactoryCompiler;
+import run.endive.corpus.BlockTypeTestModule;
+import run.endive.runtime.Instance;
+import run.endive.wasm.Parser;
+
+public class BlockTypeTest {
+
+    @Test
+    public void shouldCompileTypeIndicesThatOverlapValueTypes() {
+        var module = Parser.parse(BlockTypeTestModule.create());
+        var instance =
+                Instance.builder(module)
+                        .withMachineFactory(MachineFactoryCompiler::compile)
+                        .build();
+
+        for (var typeIndex = BlockTypeTestModule.FIRST_TYPE_INDEX;
+                typeIndex <= BlockTypeTestModule.LAST_TYPE_INDEX;
+                typeIndex++) {
+            var result = instance.export(BlockTypeTestModule.exportName(typeIndex)).apply();
+            assertEquals(typeIndex, result[0]);
+        }
+    }
+}

--- a/redline/compiler/src/main/java/run/endive/redline/experimental/compiler/internal/NativeCompiler.java
+++ b/redline/compiler/src/main/java/run/endive/redline/experimental/compiler/internal/NativeCompiler.java
@@ -16,6 +16,7 @@ import run.endive.redline.experimental.bridge.internal.CraneliftBridge;
 import run.endive.wasm.WasmEngineException;
 import run.endive.wasm.WasmModule;
 import run.endive.wasm.types.AnnotatedInstruction;
+import run.endive.wasm.types.BlockType;
 import run.endive.wasm.types.ExternalType;
 import run.endive.wasm.types.FunctionType;
 import run.endive.wasm.types.OpCode;
@@ -410,14 +411,15 @@ public final class NativeCompiler {
     // --- Block type decoding ---
 
     private FunctionType decodeBlockType(AnnotatedInstruction ins) {
-        long typeId = ins.operands()[0];
-        if (typeId == 0x40) {
+        var blockType = ins.operands()[0];
+        if (BlockType.isEmpty(blockType)) {
             return FunctionType.empty();
         }
-        if (ValType.isValid(typeId)) {
-            return FunctionType.returning(ValType.builder().fromId(typeId).build());
+        if (BlockType.isValueType(blockType)) {
+            return FunctionType.returning(
+                    ValType.builder().fromId(BlockType.valueTypeId(blockType)).build());
         }
-        return (FunctionType) module.typeSection().getType((int) typeId);
+        return (FunctionType) module.typeSection().getType((int) BlockType.typeIndex(blockType));
     }
 
     // --- Control stack helpers ---

--- a/runtime/src/main/java/run/endive/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/run/endive/runtime/InterpreterMachine.java
@@ -10,6 +10,7 @@ import java.util.List;
 import run.endive.wasm.InvalidException;
 import run.endive.wasm.WasmEngineException;
 import run.endive.wasm.types.AnnotatedInstruction;
+import run.endive.wasm.types.BlockType;
 import run.endive.wasm.types.CatchOpCode;
 import run.endive.wasm.types.FunctionType;
 import run.endive.wasm.types.Instruction;
@@ -3099,32 +3100,32 @@ public class InterpreterMachine implements Machine {
     }
 
     private static int numberOfParams(Instance instance, AnnotatedInstruction scope) {
-        var typeId = (int) scope.operand(0);
-        if (typeId == 0x40) { // epsilon
+        var blockType = scope.operand(0);
+        if (BlockType.isEmpty(blockType)) {
             return 0;
         }
-        if (ValType.isValid(typeId)) {
+        if (BlockType.isValueType(blockType)) {
             return 0;
         }
-        return sizeOf(instance.type(typeId).params());
+        return sizeOf(instance.type((int) BlockType.typeIndex(blockType)).params());
     }
 
     private static int numberOfValuesToReturn(Instance instance, AnnotatedInstruction scope) {
         if (scope.opcode() == OpCode.END) {
             return 0;
         }
-        var typeId = (int) scope.operand(0);
-        if (typeId == 0x40) { // epsilon
+        var blockType = scope.operand(0);
+        if (BlockType.isEmpty(blockType)) {
             return 0;
         }
-        if (ValType.isValid(typeId)) {
-            if (typeId == ValType.V128.id()) {
+        if (BlockType.isValueType(blockType)) {
+            if (BlockType.valueTypeId(blockType) == ValType.V128.id()) {
                 return 2;
             } else {
                 return 1;
             }
         }
-        return sizeOf(instance.type(typeId).returns());
+        return sizeOf(instance.type((int) BlockType.typeIndex(blockType)).returns());
     }
 
     protected static StackFrame THROW_REF(

--- a/runtime/src/test/java/run/endive/runtime/BlockTypeTest.java
+++ b/runtime/src/test/java/run/endive/runtime/BlockTypeTest.java
@@ -1,0 +1,22 @@
+package run.endive.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import run.endive.corpus.BlockTypeTestModule;
+import run.endive.wasm.Parser;
+
+public class BlockTypeTest {
+
+    @Test
+    public void shouldInterpretTypeIndicesThatOverlapValueTypes() {
+        var instance = Instance.builder(Parser.parse(BlockTypeTestModule.create())).build();
+
+        for (var typeIndex = BlockTypeTestModule.FIRST_TYPE_INDEX;
+                typeIndex <= BlockTypeTestModule.LAST_TYPE_INDEX;
+                typeIndex++) {
+            var result = instance.export(BlockTypeTestModule.exportName(typeIndex)).apply();
+            assertEquals(typeIndex, result[0]);
+        }
+    }
+}

--- a/wasm-corpus/src/main/java/run/endive/corpus/BlockTypeTestModule.java
+++ b/wasm-corpus/src/main/java/run/endive/corpus/BlockTypeTestModule.java
@@ -71,7 +71,7 @@ public final class BlockTypeTestModule {
         for (var typeIndex = FIRST_TYPE_INDEX; typeIndex <= LAST_TYPE_INDEX; typeIndex++) {
             var name = exportName(typeIndex).getBytes(StandardCharsets.UTF_8);
             writeUnsignedLeb(section, name.length);
-            section.writeBytes(name);
+            writeAll(section, name);
             section.write(0x00);
             writeUnsignedLeb(section, typeIndex - FIRST_TYPE_INDEX);
         }
@@ -92,7 +92,7 @@ public final class BlockTypeTestModule {
             body.write(0x0b);
 
             writeUnsignedLeb(section, body.size());
-            section.writeBytes(body.toByteArray());
+            writeAll(section, body.toByteArray());
         }
         writeSection(module, 10, section);
     }
@@ -101,7 +101,17 @@ public final class BlockTypeTestModule {
             ByteArrayOutputStream module, int sectionId, ByteArrayOutputStream section) {
         module.write(sectionId);
         writeUnsignedLeb(module, section.size());
-        module.writeBytes(section.toByteArray());
+        writeAll(module, section.toByteArray());
+    }
+
+    /**
+     * Appends every byte of {@code bytes} to {@code output}.
+     *
+     * <p>{@link ByteArrayOutputStream#writeBytes(byte[])} is Java 11 API that is missing from older
+     * Android runtimes, so the three-argument {@code write} is used instead.
+     */
+    private static void writeAll(ByteArrayOutputStream output, byte[] bytes) {
+        output.write(bytes, 0, bytes.length);
     }
 
     private static void writeUnsignedLeb(ByteArrayOutputStream output, long value) {

--- a/wasm-corpus/src/main/java/run/endive/corpus/BlockTypeTestModule.java
+++ b/wasm-corpus/src/main/java/run/endive/corpus/BlockTypeTestModule.java
@@ -1,0 +1,131 @@
+package run.endive.corpus;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+/** Builds small Wasm modules for block-type regression tests. */
+public final class BlockTypeTestModule {
+    public static final int FIRST_TYPE_INDEX = 63;
+    public static final int LAST_TYPE_INDEX = 128;
+
+    private static final int FUNCTION_COUNT = LAST_TYPE_INDEX - FIRST_TYPE_INDEX + 1;
+
+    private BlockTypeTestModule() {}
+
+    /**
+     * Returns a module with one exported function for each type index from 63 through 128.
+     *
+     * <p>Every type has signature {@code () -> i32}. Each function contains a block whose type is
+     * referenced by the corresponding type-section index and returns that index. This range covers
+     * the boundary at index 64 and every index that overlaps a one-byte value-type opcode.
+     */
+    public static byte[] create() {
+        var module = new ByteArrayOutputStream();
+        module.write(0x00);
+        module.write(0x61);
+        module.write(0x73);
+        module.write(0x6d);
+        module.write(0x01);
+        module.write(0x00);
+        module.write(0x00);
+        module.write(0x00);
+
+        writeTypeSection(module);
+        writeFunctionSection(module);
+        writeExportSection(module);
+        writeCodeSection(module);
+        return module.toByteArray();
+    }
+
+    public static String exportName(int typeIndex) {
+        if (typeIndex < FIRST_TYPE_INDEX || typeIndex > LAST_TYPE_INDEX) {
+            throw new IllegalArgumentException("type index outside the test module range");
+        }
+        return "type" + typeIndex;
+    }
+
+    private static void writeTypeSection(ByteArrayOutputStream module) {
+        var section = new ByteArrayOutputStream();
+        writeUnsignedLeb(section, LAST_TYPE_INDEX + 1L);
+        for (var i = 0; i <= LAST_TYPE_INDEX; i++) {
+            section.write(0x60);
+            section.write(0x00);
+            section.write(0x01);
+            section.write(0x7f);
+        }
+        writeSection(module, 1, section);
+    }
+
+    private static void writeFunctionSection(ByteArrayOutputStream module) {
+        var section = new ByteArrayOutputStream();
+        writeUnsignedLeb(section, FUNCTION_COUNT);
+        for (var i = 0; i < FUNCTION_COUNT; i++) {
+            writeUnsignedLeb(section, 0);
+        }
+        writeSection(module, 3, section);
+    }
+
+    private static void writeExportSection(ByteArrayOutputStream module) {
+        var section = new ByteArrayOutputStream();
+        writeUnsignedLeb(section, FUNCTION_COUNT);
+        for (var typeIndex = FIRST_TYPE_INDEX; typeIndex <= LAST_TYPE_INDEX; typeIndex++) {
+            var name = exportName(typeIndex).getBytes(StandardCharsets.UTF_8);
+            writeUnsignedLeb(section, name.length);
+            section.writeBytes(name);
+            section.write(0x00);
+            writeUnsignedLeb(section, typeIndex - FIRST_TYPE_INDEX);
+        }
+        writeSection(module, 7, section);
+    }
+
+    private static void writeCodeSection(ByteArrayOutputStream module) {
+        var section = new ByteArrayOutputStream();
+        writeUnsignedLeb(section, FUNCTION_COUNT);
+        for (var typeIndex = FIRST_TYPE_INDEX; typeIndex <= LAST_TYPE_INDEX; typeIndex++) {
+            var body = new ByteArrayOutputStream();
+            body.write(0x00);
+            body.write(0x02);
+            writeSignedLeb(body, typeIndex);
+            body.write(0x41);
+            writeSignedLeb(body, typeIndex);
+            body.write(0x0b);
+            body.write(0x0b);
+
+            writeUnsignedLeb(section, body.size());
+            section.writeBytes(body.toByteArray());
+        }
+        writeSection(module, 10, section);
+    }
+
+    private static void writeSection(
+            ByteArrayOutputStream module, int sectionId, ByteArrayOutputStream section) {
+        module.write(sectionId);
+        writeUnsignedLeb(module, section.size());
+        module.writeBytes(section.toByteArray());
+    }
+
+    private static void writeUnsignedLeb(ByteArrayOutputStream output, long value) {
+        do {
+            var next = (int) (value & 0x7f);
+            value >>>= 7;
+            if (value != 0) {
+                next |= 0x80;
+            }
+            output.write(next);
+        } while (value != 0);
+    }
+
+    private static void writeSignedLeb(ByteArrayOutputStream output, long value) {
+        boolean more;
+        do {
+            var next = (int) (value & 0x7f);
+            value >>= 7;
+            var signBitSet = (next & 0x40) != 0;
+            more = !((value == 0 && !signBitSet) || (value == -1 && signBitSet));
+            if (more) {
+                next |= 0x80;
+            }
+            output.write(next);
+        } while (more);
+    }
+}

--- a/wasm/src/main/java/run/endive/wasm/Parser.java
+++ b/wasm/src/main/java/run/endive/wasm/Parser.java
@@ -40,6 +40,7 @@ import run.endive.wasm.types.ActiveDataSegment;
 import run.endive.wasm.types.ActiveElement;
 import run.endive.wasm.types.AnnotatedInstruction;
 import run.endive.wasm.types.ArrayType;
+import run.endive.wasm.types.BlockType;
 import run.endive.wasm.types.CatchOpCode;
 import run.endive.wasm.types.CodeSection;
 import run.endive.wasm.types.CompType;
@@ -1354,14 +1355,7 @@ public final class Parser {
                         break;
                     }
                 case BLOCK_TYPE:
-                    var operand = (int) readVarUInt32(buffer);
-                    if (ValType.ID.isValidOpcode(operand)) {
-                        // is value type
-                        ValType.Builder v = readValueTypeBuilderFromOpCode(buffer, operand);
-                        operands.add(v.id());
-                    } else {
-                        operands.add((long) operand);
-                    }
+                    operands.add(readBlockType(buffer));
                     break;
                 case VEC_VALUE_TYPE:
                     var vcount = (int) readVarUInt32(buffer);
@@ -1403,6 +1397,54 @@ public final class Parser {
         }
         verifyAlignment(op, operandsArray);
         return new Instruction(address, op, operandsArray);
+    }
+
+    private static long readBlockType(ByteBuffer buffer) {
+        var blockType = readSignedBlockType(buffer);
+        if (blockType >= 0) {
+            return BlockType.forTypeIndex(blockType);
+        }
+        if (blockType == -0x40) {
+            return BlockType.empty();
+        }
+        if (blockType < -0x40) {
+            throw new MalformedException("invalid block type");
+        }
+
+        var valueTypeOpCode = Math.toIntExact(blockType + 0x80);
+        if (!ValType.ID.isValidOpcode(valueTypeOpCode)) {
+            throw new MalformedException("invalid block type");
+        }
+        return BlockType.forValueType(readValueTypeBuilderFromOpCode(buffer, valueTypeOpCode).id());
+    }
+
+    private static long readSignedBlockType(ByteBuffer buffer) {
+        long result = 0;
+        int shift = 0;
+
+        // A block type is encoded as s33, which occupies at most five bytes.
+        for (var i = 0; i < 5; i++) {
+            var currentByte = Byte.toUnsignedInt(readByte(buffer));
+            var payload = currentByte & 0x7f;
+
+            // Only five payload bits belong to s33 in the final byte. The remaining
+            // bits must be either all zero or all one according to the sign bit.
+            if (i == 4 && payload > 0x0f && payload < 0x70) {
+                throw new MalformedException("integer too large");
+            }
+
+            result |= (long) payload << shift;
+            shift += 7;
+
+            if ((currentByte & 0x80) == 0) {
+                if ((currentByte & 0x40) != 0) {
+                    result |= -1L << shift;
+                }
+                return result;
+            }
+        }
+
+        throw new MalformedException("integer representation too long");
     }
 
     private static void verifyAlignment(OpCode op, long[] operands) {

--- a/wasm/src/main/java/run/endive/wasm/Validator.java
+++ b/wasm/src/main/java/run/endive/wasm/Validator.java
@@ -16,6 +16,7 @@ import run.endive.wasm.types.ActiveDataSegment;
 import run.endive.wasm.types.ActiveElement;
 import run.endive.wasm.types.AnnotatedInstruction;
 import run.endive.wasm.types.ArrayType;
+import run.endive.wasm.types.BlockType;
 import run.endive.wasm.types.CatchOpCode;
 import run.endive.wasm.types.CompType;
 import run.endive.wasm.types.Element;
@@ -348,28 +349,29 @@ final class Validator {
     }
 
     private List<ValType> getReturns(AnnotatedInstruction op) {
-        var typeId = op.operand(0);
-        if (typeId == 0x40) { // epsilon
+        var blockType = op.operand(0);
+        if (BlockType.isEmpty(blockType)) {
             return List.of();
         }
-        if (ValType.isValid(typeId)) {
-            return List.of(valType(typeId));
+        if (BlockType.isValueType(blockType)) {
+            return List.of(valType(BlockType.valueTypeId(blockType)));
         }
-        return getType((int) typeId).returns();
+        return getType((int) BlockType.typeIndex(blockType)).returns();
     }
 
     private List<ValType> getParams(AnnotatedInstruction op) {
-        var typeId = op.operand(0);
-        if (typeId == 0x40) { // epsilon
+        var blockType = op.operand(0);
+        if (BlockType.isEmpty(blockType)) {
             return List.of();
         }
-        if (ValType.isValid(typeId)) {
+        if (BlockType.isValueType(blockType)) {
             return List.of();
         }
-        if (typeId >= module.typeSection().subTypeCount()) {
+        var typeIndex = BlockType.typeIndex(blockType);
+        if (typeIndex >= module.typeSection().subTypeCount()) {
             throw new MalformedException("unexpected end");
         }
-        return getType((int) typeId).params();
+        return getType((int) typeIndex).params();
     }
 
     private ValType getLocalType(int idx) {

--- a/wasm/src/main/java/run/endive/wasm/types/BlockType.java
+++ b/wasm/src/main/java/run/endive/wasm/types/BlockType.java
@@ -1,0 +1,70 @@
+package run.endive.wasm.types;
+
+/**
+ * Encodes the three distinct forms of a WebAssembly block type in an instruction operand.
+ *
+ * <p>The binary format uses a signed {@code s33}: negative values denote inline value types,
+ * {@code -0x40} denotes the empty block type, and non-negative values denote type-section
+ * indices. These forms must remain distinct after decoding because the raw value-type opcodes
+ * overlap valid type indices.
+ */
+public final class BlockType {
+    private static final long KIND_MASK = 0xc000_0000_0000_0000L;
+    private static final long VALUE_TYPE_KIND = 0x4000_0000_0000_0000L;
+    private static final long EMPTY_KIND = 0x8000_0000_0000_0000L;
+    private static final long TYPE_INDEX_MASK = 0xffff_ffffL;
+    private static final long VALUE_TYPE_PAYLOAD_MASK = 0xffff_ffffffL;
+
+    private BlockType() {}
+
+    public static long empty() {
+        return EMPTY_KIND;
+    }
+
+    public static long forTypeIndex(long typeIndex) {
+        if (typeIndex < 0 || typeIndex > TYPE_INDEX_MASK) {
+            throw new IllegalArgumentException("block type index must be an unsigned 32-bit value");
+        }
+        return typeIndex;
+    }
+
+    public static long forValueType(long valueTypeId) {
+        if (!ValType.isValid(valueTypeId)) {
+            throw new IllegalArgumentException("invalid block value type");
+        }
+
+        var valueType = ValType.builder().fromId(valueTypeId).build();
+        var typeIndex = Integer.toUnsignedLong(valueType.typeIdx());
+        return VALUE_TYPE_KIND | (typeIndex << 8) | valueType.opcode();
+    }
+
+    public static boolean isEmpty(long blockType) {
+        return blockType == EMPTY_KIND;
+    }
+
+    public static boolean isTypeIndex(long blockType) {
+        return (blockType & KIND_MASK) == 0 && blockType <= TYPE_INDEX_MASK;
+    }
+
+    public static boolean isValueType(long blockType) {
+        return (blockType & KIND_MASK) == VALUE_TYPE_KIND
+                && (blockType & ~(KIND_MASK | VALUE_TYPE_PAYLOAD_MASK)) == 0;
+    }
+
+    public static long typeIndex(long blockType) {
+        if (!isTypeIndex(blockType)) {
+            throw new IllegalArgumentException("block type is not a type index");
+        }
+        return blockType;
+    }
+
+    public static long valueTypeId(long blockType) {
+        if (!isValueType(blockType)) {
+            throw new IllegalArgumentException("block type is not a value type");
+        }
+
+        var opcode = (int) (blockType & 0xff);
+        var typeIndex = (int) ((blockType >>> 8) & TYPE_INDEX_MASK);
+        return ValType.builder().withOpcode(opcode).withTypeIdx(typeIndex).id();
+    }
+}

--- a/wasm/src/test/java/run/endive/wasm/ParserTest.java
+++ b/wasm/src/test/java/run/endive/wasm/ParserTest.java
@@ -4,9 +4,11 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -18,8 +20,11 @@ import java.util.Locale;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import run.endive.corpus.BlockTypeTestModule;
 import run.endive.corpus.CorpusResources;
 import run.endive.wasm.types.ActiveDataSegment;
+import run.endive.wasm.types.BlockType;
+import run.endive.wasm.types.CodeSection;
 import run.endive.wasm.types.CustomSection;
 import run.endive.wasm.types.ExternalType;
 import run.endive.wasm.types.OpCode;
@@ -183,6 +188,114 @@ public class ParserTest {
             assertEquals(-1L, fbody.instructions().get(24).operand(0));
             assertEquals(1L, fbody.instructions().get(26).operand(0));
         }
+    }
+
+    @Test
+    public void shouldParseSignedBlockTypes() {
+        assertEquals(ValType.I32.id(), BlockType.valueTypeId(parseBlockType((byte) 0x7f)));
+        assertEquals(
+                ValType.I32.id(), BlockType.valueTypeId(parseBlockType((byte) 0xff, (byte) 0x7f)));
+        assertEquals(
+                ValType.FuncRef.id(),
+                BlockType.valueTypeId(parseBlockType((byte) 0x63, (byte) 0x70)));
+        assertTrue(BlockType.isEmpty(parseBlockType((byte) 0x40)));
+        assertTrue(BlockType.isEmpty(parseBlockType((byte) 0xc0, (byte) 0x7f)));
+        assertEquals(127L, BlockType.typeIndex(parseBlockType((byte) 0xff, (byte) 0x00)));
+        assertEquals(
+                0xffff_ffffL,
+                BlockType.typeIndex(
+                        parseBlockType(
+                                (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0x0f)));
+        assertFalse(
+                BlockType.empty() == BlockType.forTypeIndex(64),
+                "empty block types and type index 64 must have distinct operands");
+    }
+
+    @Test
+    public void shouldValidateTypeIndicesThatOverlapValueTypes() {
+        var module = Parser.parse(BlockTypeTestModule.create());
+
+        for (var typeIndex = BlockTypeTestModule.FIRST_TYPE_INDEX;
+                typeIndex <= BlockTypeTestModule.LAST_TYPE_INDEX;
+                typeIndex++) {
+            var functionIndex = typeIndex - BlockTypeTestModule.FIRST_TYPE_INDEX;
+            var block = module.codeSection().getFunctionBody(functionIndex).instructions().get(0);
+            assertEquals(OpCode.BLOCK, block.opcode());
+            assertEquals(typeIndex, BlockType.typeIndex(block.operand(0)));
+        }
+    }
+
+    @Test
+    public void shouldRejectInvalidSignedBlockTypes() {
+        assertThrows(MalformedException.class, () -> parseBlockType((byte) 0xbf, (byte) 0x7f));
+        assertThrows(
+                MalformedException.class,
+                () ->
+                        parseBlockType(
+                                (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x10));
+        assertThrows(
+                MalformedException.class,
+                () ->
+                        parseBlockType(
+                                (byte) 0x80,
+                                (byte) 0x80,
+                                (byte) 0x80,
+                                (byte) 0x80,
+                                (byte) 0x80,
+                                (byte) 0x00));
+    }
+
+    private static long parseBlockType(byte... blockType) {
+        var bodySize = blockType.length + 4;
+        var codeSectionSize = bodySize + 2;
+        var wasm = new byte[8 + 6 + 4 + 2 + codeSectionSize];
+        var offset = 0;
+
+        byte[] prefix = {
+            0x00,
+            0x61,
+            0x73,
+            0x6d,
+            0x01,
+            0x00,
+            0x00,
+            0x00,
+            0x01,
+            0x04,
+            0x01,
+            0x60,
+            0x00,
+            0x00,
+            0x03,
+            0x02,
+            0x01,
+            0x00,
+            0x0a,
+            (byte) codeSectionSize,
+            0x01,
+            (byte) bodySize,
+            0x00,
+            0x02
+        };
+        System.arraycopy(prefix, 0, wasm, offset, prefix.length);
+        offset += prefix.length;
+        System.arraycopy(blockType, 0, wasm, offset, blockType.length);
+        offset += blockType.length;
+        wasm[offset++] = 0x0b;
+        wasm[offset] = 0x0b;
+
+        var codeSection = new CodeSection[1];
+        Parser.builder()
+                .build()
+                .parse(
+                        new ByteArrayInputStream(wasm),
+                        section -> {
+                            if (section.sectionId() == SectionId.CODE) {
+                                codeSection[0] = (CodeSection) section;
+                            }
+                        });
+
+        return codeSection[0].getFunctionBody(0).instructions().get(0).operand(0);
     }
 
     @Test


### PR DESCRIPTION
Block types were incorrectly decoded as u32, instead of s33. Additionally value types and type indices were stored in the same untagged way. This could cause overlaps of type indices and value types in rare cases. Rarely happens in regular WASM modules, but can occur in modules that use multi-value block types and have a very large type section.
For reference, see the note at: https://webassembly.github.io/spec/core/binary/instructions.html#binary-blocktype