### PR TITLE
Use Spotless' built-in `forbidWildcardImports`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -976,18 +976,7 @@
                   <formatJavadoc>false</formatJavadoc>
                 </googleJavaFormat>
                 <importOrder/>
-                <jsr223>
-                  <name>Wildcard Imports Not Allowed</name>
-                  <dependency>io.roastedroot:quickjs4j-scripting-experimental:0.0.14</dependency>
-                  <engine>quickjs4j</engine>
-                  <script>var pattern = /import\s+(?:static\s+)?[^\*\s]+\*;(\r\n|\r|\n)/;
-                var match = source.match(pattern);
-                if (match) {
-                   var importText = match[0].trim();
-                   throw new Error("Wildcard imports not allowed:\n\n    " + importText + "\n\nPlease fully expand the imports.\n");
-                }
-                source</script>
-                </jsr223>
+                <forbidWildcardImports/>
                 <removeUnusedImports/>
               </java>
               <pom>


### PR DESCRIPTION
Did a quick test and it seems to detect wildcard imports as well. And it is probably easier to use and maintain than the previous custom script.