### PR TITLE
[chore] Improve documentation content

### DIFF
--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -5,7 +5,11 @@ title: Installation
 ---
 # Installation
 
+Endive requires **Java 11** or later.
+
 Add Endive to your project using Maven or Gradle.
+
+[![Maven Central](https://img.shields.io/maven-central/v/run.endive/runtime)](https://central.sonatype.com/artifact/run.endive/runtime)
 
 ## Maven
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -4,7 +4,13 @@ sidebar_label: Quick Start
 title: Quick start
 ---
 
+:::info[Requirements]
+Endive requires **Java 11** or later. SIMD support requires Java 21+.
+:::
+
 ### Install the dependency
+
+[![Maven Central](https://img.shields.io/maven-central/v/run.endive/runtime)](https://central.sonatype.com/artifact/run.endive/runtime)
 
 To use the runtime, you need to add the `run.endive:runtime` dependency
 to your dependency management system.
@@ -63,6 +69,10 @@ import java.io.File;
 var module = Parser.parse(new File("./factorial.wasm"));
 Instance instance = Instance.builder(module).build();
 ```
+
+:::note[Threading]
+`Instance` and `Store` are not thread-safe. Create separate instances per thread, or synchronize access externally. Memory operations (used by the Wasm threads proposal) are thread-safe.
+:::
 
 You can think of the `module` as of inert code, and the `instance` 
 is the run-time representation of that code: a virtual machine ready to execute.

--- a/docs/scripts/generate-llm-files.mjs
+++ b/docs/scripts/generate-llm-files.mjs
@@ -182,9 +182,14 @@ function generateLlmsFullTxt(docEntries, blogEntries) {
     sections.push(cleanContent(entry.content));
   }
 
+  if (blogEntries.length > 0) {
+    sections.push('---', '', '# Blog Posts', '',
+      '> The following are blog posts, not reference documentation.', '');
+  }
+
   for (const entry of blogEntries) {
     sections.push('---', '');
-    sections.push(`## Blog: ${entry.title}`);
+    sections.push(`## ${entry.title}`);
     sections.push('');
     sections.push(cleanContent(entry.content));
   }


### PR DESCRIPTION
- Add Maven Central badge to Quick Start and Installation pages
- State Java 11 minimum requirement in Quick Start and Installation
- Add threading note: Instance and Store are not thread-safe
- Separate blog posts from reference docs in llms-full.txt