### PR TITLE
Throw dedicated exception instead of `RuntimeException`

### DIFF
--- a/compiler/src/main/java/run/endive/compiler/internal/TypeStack.java
+++ b/compiler/src/main/java/run/endive/compiler/internal/TypeStack.java
@@ -6,6 +6,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
+import run.endive.wasm.InvalidException;
 import run.endive.wasm.types.FunctionType;
 import run.endive.wasm.types.Instruction;
 import run.endive.wasm.types.OpCode;
@@ -91,10 +92,10 @@ final class TypeStack {
 
     public void verifyEmpty() {
         if (types.size() != 1) {
-            throw new RuntimeException("Bad types stack: " + types);
+            throw new InvalidException("Bad types stack: " + types);
         }
         if (!types().isEmpty()) {
-            throw new RuntimeException("Types not empty: " + types());
+            throw new InvalidException("Types not empty: " + types());
         }
     }
 }

--- a/runtime/src/main/java/run/endive/runtime/InterpreterMachine.java
+++ b/runtime/src/main/java/run/endive/runtime/InterpreterMachine.java
@@ -58,7 +58,7 @@ public class InterpreterMachine implements Machine {
             Instruction instruction,
             Operands operands)
             throws WasmEngineException {
-        throw new RuntimeException("Machine doesn't recognize Instruction " + instruction);
+        throw new WasmEngineException("Machine doesn't recognize Instruction " + instruction);
     }
 
     @Override


### PR DESCRIPTION
Both of these cases were reachable during fuzzing; see related https://github.com/bytecodealliance/endive/pull/146#discussion_r3766143684.

I hope the chosen exception types are reasonable.