### PR TITLE
Read data segments without copying

### DIFF
--- a/jmh/src/main/java/run/endive/bench/BenchmarkDataSegments.java
+++ b/jmh/src/main/java/run/endive/bench/BenchmarkDataSegments.java
@@ -1,0 +1,81 @@
+package run.endive.bench;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import run.endive.runtime.ExportFunction;
+import run.endive.runtime.Instance;
+import run.endive.wabt.Wat2Wasm;
+import run.endive.wasm.Parser;
+import run.endive.wasm.WasmModule;
+
+/**
+ * Measures the cost of reading data segments: once per instance for an active segment, and once per
+ * {@code memory.init} for a passive one.
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(1)
+public class BenchmarkDataSegments {
+
+    // Bytes written by each memory.init, much smaller than the segment itself
+    private static final int INIT_SIZE = 64;
+
+    @Param({"1024", "1048576"})
+    private int segmentSize;
+
+    private WasmModule activeModule;
+    private ExportFunction memoryInit;
+
+    @Setup
+    public void setup() {
+        var data = "\\00".repeat(segmentSize);
+        var pages = (segmentSize / 65536) + 1;
+
+        activeModule =
+                Parser.parse(
+                        Wat2Wasm.parse(
+                                "(module (memory "
+                                        + pages
+                                        + ") (data (i32.const 0) \""
+                                        + data
+                                        + "\"))"));
+
+        var passiveModule =
+                Parser.parse(
+                        Wat2Wasm.parse(
+                                "(module (memory "
+                                        + pages
+                                        + ") (data $seg \""
+                                        + data
+                                        + "\")"
+                                        + " (func (export \"init\") (param i32 i32 i32)"
+                                        + " local.get 0 local.get 1 local.get 2"
+                                        + " memory.init $seg))"));
+        memoryInit = Instance.builder(passiveModule).build().export("init");
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void benchmarkInstantiate(Blackhole bh) {
+        bh.consume(Instance.builder(activeModule).build());
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void benchmarkMemoryInit(Blackhole bh) {
+        bh.consume(memoryInit.apply(0, 0, INIT_SIZE));
+    }
+}

--- a/runtime/src/main/java/run/endive/runtime/ByteArrayMemory.java
+++ b/runtime/src/main/java/run/endive/runtime/ByteArrayMemory.java
@@ -318,7 +318,7 @@ public final class ByteArrayMemory implements Memory {
                     continue;
                 }
                 var offsetExpr = segment.offsetInstructions();
-                var data = segment.data();
+                var data = segment.bytes();
                 var offset = (int) computeConstantValue(instance, offsetExpr)[0];
                 checkBounds(offset, data.length, sizeInBytes(), UninstantiableException::new);
                 write(offset, data, 0, data.length);
@@ -369,7 +369,7 @@ public final class ByteArrayMemory implements Memory {
     @Override
     public void initPassiveSegment(int segmentId, int dest, int offset, int size) {
         var segment = dataSegments[segmentId];
-        write(dest, segment.data(), offset, size);
+        write(dest, segment.bytes(), offset, size);
     }
 
     private int sizeInBytes() {

--- a/runtime/src/main/java/run/endive/runtime/ByteBufferMemory.java
+++ b/runtime/src/main/java/run/endive/runtime/ByteBufferMemory.java
@@ -282,7 +282,7 @@ public final class ByteBufferMemory implements Memory {
                     continue;
                 }
                 var offsetExpr = segment.offsetInstructions();
-                var data = segment.data();
+                var data = segment.bytes();
                 var offset = (int) computeConstantValue(instance, offsetExpr)[0];
                 checkBounds(offset, data.length, sizeInBytes(), UninstantiableException::new);
                 write(offset, data, 0, data.length);
@@ -335,7 +335,7 @@ public final class ByteBufferMemory implements Memory {
     @Override
     public void initPassiveSegment(int segmentId, int dest, int offset, int size) {
         var segment = dataSegments[segmentId];
-        write(dest, segment.data(), offset, size);
+        write(dest, segment.bytes(), offset, size);
     }
 
     private int sizeInBytes() {

--- a/runtime/src/main/java/run/endive/runtime/Instance.java
+++ b/runtime/src/main/java/run/endive/runtime/Instance.java
@@ -383,7 +383,7 @@ public class Instance implements AutoCloseable {
     }
 
     public byte[] dataSegmentData(int idx) {
-        return dataSegments[idx].data();
+        return dataSegments[idx].bytes();
     }
 
     public void dropDataSegment(int idx) {

--- a/wasm/src/main/java/run/endive/wasm/types/DataSegment.java
+++ b/wasm/src/main/java/run/endive/wasm/types/DataSegment.java
@@ -14,6 +14,18 @@ public abstract class DataSegment {
         return data.clone();
     }
 
+    /**
+     * The segment's bytes, without copying. The returned array is the segment's own storage,
+     * shared with every other reader, and must never be modified.
+     *
+     * <p>Use {@link #data()} unless the copy it makes is unaffordable. This method exists for
+     * read-only consumers that access a segment repeatedly, where copying it every time would
+     * cost more than the read itself.
+     */
+    public byte[] bytes() {
+        return data;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {


### PR DESCRIPTION
JMH results — java -jar jmh/target/benchmarks.jar BenchmarkDataSegments -f 1 -wi 3 -i 5 -r 3s, throughput in ops/s, baseline taken by stashing the four source files:

```
before       after
memory.init, 64B write, 1MiB segment      4,602   5,931,244    ~1300x
memory.init, 64B write, 1KiB segment  3,671,413   5,882,892     ~1.6x
instantiate, 1MiB active segment          1,628       3,341     ~2x
instantiate, 1KiB active segment         31,402      29,439     noise
```

The headline is the first row: memory.init used to cost time proportional to the segment size instead of to the 64 bytes it actually writes.